### PR TITLE
adding vim swp files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 docs/
+*.swp


### PR DESCRIPTION
simple fix to also ignore vi/vim swap files.