### PR TITLE
fixes to urls

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,4 +10,4 @@ cover:
 
 Welcome to the Open Practice Library. Here, we look to provide information on the [Practices and Techniques](/practices) that empower teams to collaborate and deliver iteratively.
 
-The library's source is in [a public GitHub repo](https://openpracticelibrary.netlify.com/) and is licensed under [Apache 2.0](https://github.com/rht-labs/practice-library/blob/master/LICENSE). Feedback and contributions are welcome! [Learn more about contributing](/about/#contributing).
+The library's source is in [a public GitHub repo](https://github.com/openpracticelibrary/openpracticelibrary) and is licensed under [Apache 2.0](https://github.com/openpracticelibrary/openpracticelibrary/blob/master/LICENSE). Feedback and contributions are welcome! [Learn more about contributing](/about/#contributing).

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -23,9 +23,9 @@ Just enough information for each practice to "specify the end state, it’s purp
 
 ## Contributing
 
-We'd love to hear your thoughts about the material presented here or other content you'd like to add. [Open an issue](https://github.com/rht-labs/practice-library/issues) and we can go from there.
+We'd love to hear your thoughts about the material presented here or other content you'd like to add. [Open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) and we can go from there.
 
-Alternately, feel free to fork our [github repo](https://github.com/rht-labs/practice-library) and submit a PR of your proposed changes. We use markdown files for our base content that gets rendered for this site. For helpful development setup see our [README](https://github.com/rht-labs/practice-library/blob/master/README.md)
+Alternately, feel free to fork our [github repo](https://github.com/openpracticelibrary/openpracticelibrary) and submit a PR of your proposed changes. We use markdown files for our base content that gets rendered for this site. For helpful development setup see our [README](https://github.com/openpracticelibrary/openpracticelibrary/blob/master/README.md)
 
 ## Style
 

--- a/content/practices/event-storming.md
+++ b/content/practices/event-storming.md
@@ -31,7 +31,7 @@ Event Storming is a rapid, interactive approach to business process discovery an
 
 ## Related Practices
 
-- [User Story Mapping](https://rht-labs.github.io/practice-library/practices/user-story-mapping/) is a great way to create an Agile delivery plan for a business process designed with Event Storming
+- [User Story Mapping](/practices/user-story-mapping/) is a great way to create an Agile delivery plan for a business process designed with Event Storming
 - Journey Mapping[<sup>4</sup>](#footnote-4) can provide a high level overview of the business process before using Event Storming to get into the details
 - Event Storming will identify key views for your user interface, which can jump start Site Mapping[<sup>5</sup>](#footnote-5) or Wireframing[<sup>6</sup>](#footnote-6)
 


### PR DESCRIPTION
As this repo has been moved to a different github org I've made some fixes to point to the new github organisation in the links in the source.