### PR TITLE
Adding a copyright notice on each page.

### DIFF
--- a/layouts/partials/footer/copyright.html
+++ b/layouts/partials/footer/copyright.html
@@ -1,0 +1,2 @@
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>
+<br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.


### PR DESCRIPTION
Problem: Pages don't have a copyright notice.
Solution: Hugo has a built-in partial `partials/footer/copyright.html` that you can use to drop some html code and it's picked up by our template.

As we discussed on email, we wanted to make this available using CC BY-SA 4.0.

**Please don't accept this PR if we are not in agreement on the license for this library and lets continue the discussion on our mailing list.**