### PR TITLE
Update configuration for new setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .DS_Store
 node_modules/
-docs/
 *.swp
+
+# Old publish directory (from when we used GitHub pages)
+docs/
+# New publish directory
+public/

--- a/build.sh
+++ b/build.sh
@@ -27,11 +27,11 @@ _printBuildStep(){
   if [[ ${rc} != 0 ]];then
     exit ${rc}
   fi
-} 
+}
 
 clean(){
-    _printBuildStep "rm -rvf docs"
-} 
+    _printBuildStep "rm -rvf public"
+}
 
 test(){
     _printBuildStep "echo test-command"

--- a/config.toml
+++ b/config.toml
@@ -1,14 +1,11 @@
 # https://gohugo.io/getting-started/configuration/
 # https://github.com/MunifTanjim/minimo/blob/master/exampleSite/config.toml
 
-
 baseURL = "http://openpracticelibrary.com/"
 
 languageCode = "en-us"
 title = "Open Practice Library"
 theme = "minimo"
-# Why "docs" and not "public"? https://git.io/vXzj6
-publishDir = "docs"
 googleAnalytics = "UA-111461618-1"
 
 [params.assets]

--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@
 # https://github.com/MunifTanjim/minimo/blob/master/exampleSite/config.toml
 
 
-baseURL = "https://optimistic-kilby-438ca3.netlify.com/"
+baseURL = "http://openpracticelibrary.com/"
 
 languageCode = "en-us"
 title = "Open Practice Library"

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   # This will be your default build command
   command = "./build.sh"
   # This is the directory that you are publishing from (relative to root of your repo)
-  publish = "docs"
+  publish = "public"
 [context.deploy-preview.environment]
   HUGO_VERSION = "0.44"
 


### PR DESCRIPTION
- Use the correct domain in our config. (This isn't a problem for now but could break if we use absolute URLs.)
- Use the `public` folder rather than the `docs` folder. (GitHub pages required `docs`, but a more common pattern for our use case is to use `public`. That's also Hugo's default.)