### PR TITLE
Suggestions and page type fix

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -158,6 +158,4 @@
 
 </main>
 
-{{ partial "suggestions.html" . }}
-
 {{ partial "footer.html" . }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -153,8 +153,6 @@
 
   <footer class="post-footer">
 
-    <div>PAGE SINGLE</div>
-
     {{ partial "share.html" . }}
 
     {{ partial "disqus.html" . }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -153,6 +153,8 @@
 
   <footer class="post-footer">
 
+    <div>PAGE SINGLE</div>
+
     {{ partial "share.html" . }}
 
     {{ partial "disqus.html" . }}
@@ -161,7 +163,5 @@
 </article>
 
 </main>
-
-{{ partial "suggestions.html" . }}
 
 {{ partial "footer.html" . }}

--- a/layouts/practices/single.html
+++ b/layouts/practices/single.html
@@ -152,6 +152,17 @@
 
 
   <footer class="post-footer">
+    {{ $scratch := newScratch }}
+    {{ range $.Params.authors }}
+      {{ $currrentAuthor := index $.Site.Data.content.authors .}}
+      {{ $scratch.Add "listOfAuthors" (slice $currrentAuthor) }}
+    {{ end }}
+    {{ $listOfAuthors := $scratch.Get "listOfAuthors"}}
+    {{ partial "author.html" $listOfAuthors }}  
+
+    {{ partial "share.html" . }}
+
+    {{ partial "disqus.html" . }}
 
   </footer>
 </article>


### PR DESCRIPTION
**what does this PR do?**
* Fixes the fact that all practice pages were being set as the _default single page. 
* Added a `practices` folder to the layout which is the styling etc for all practices now. 
* Removed the author stuff from default page type
* Fixed the what to read next by removing it from the `Page` type 