### PR TITLE
FIX - updated URL for the chat in the menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,4 +30,4 @@ page = "/:slug/"
   name = "Gitter"
   weight = 1
   identifier = "Gitter"
-  url = "https://gitter.im/Open-Practice-Library/"
+  url = "https://gitter.im/openpracticelibrary/"


### PR DESCRIPTION
**What does this do?**

Fixes the url for the gitter room in the menu as we should now point to the new non hyphenated address.