### PR TITLE
Fix broken internal links

### DIFF
--- a/content/practice/agile-agenda.md
+++ b/content/practice/agile-agenda.md
@@ -15,7 +15,7 @@ The Agile Agenda is a simple, yet effective way to manage the agenda for an in p
 
 ## Why use an Agile Agenda?
 
-- Sessions like [event storming](/practices/event-storming/) or [user story mapping](/practices/user-story-mapping/) don't neatly fit into time boxes. As such, you'll need to dynamic with the way you manage the agenda.
+- Sessions like [event storming](/practice/event-storming/) or [user story mapping](/practice/user-story-mapping/) don't neatly fit into time boxes. As such, you'll need to dynamic with the way you manage the agenda.
 - Whiteboards and stickies are easier to change than digital agendas which might need some formatting or even have access issues.
 - It works as an Information Radiator[<sup>1</sup>](#footnote-1) throughout the workshop, making it a logical area to gather the team to review the agenda as well as do time checks. Compare this to an agenda captured in a slide deck, which doesn't naturally lead to a team huddle.
 

--- a/content/practice/burndown.md
+++ b/content/practice/burndown.md
@@ -22,7 +22,7 @@ Burndown charts provide real data about a team's velocity and provides a mechani
 
 ## Related Practices
 
-[Retrospectives](/practices/realtime-retrospective/) provide excellent opportunities to review recent burndown charts and to facilitate conversations on what can be learned from the data presented in them. 
+[Retrospectives](/practice/realtime-retrospective/) provide excellent opportunities to review recent burndown charts and to facilitate conversations on what can be learned from the data presented in them. 
 
 
 ## Who do you need?

--- a/content/practice/event-storming.md
+++ b/content/practice/event-storming.md
@@ -33,7 +33,7 @@ Event Storming is a rapid, interactive approach to business process discovery an
 
 ## Related Practices
 
-- [User Story Mapping](/practices/user-story-mapping/) is a great way to create an Agile delivery plan for a business process designed with Event Storming
+- [User Story Mapping](/practice/user-story-mapping/) is a great way to create an Agile delivery plan for a business process designed with Event Storming
 - Journey Mapping[<sup>4</sup>](#footnote-4) can provide a high level overview of the business process before using Event Storming to get into the details
 - Event Storming will identify key views for your user interface, which can jump start Site Mapping[<sup>5</sup>](#footnote-5) or Wireframing[<sup>6</sup>](#footnote-6)
 

--- a/content/practice/impact-mapping.md
+++ b/content/practice/impact-mapping.md
@@ -28,7 +28,7 @@ Impact Mapping is an engaging, graphical, strategic planning technique. It was i
 
 ## Related Practices
 
-- [Start At The End](/practices/start-at-the-end/) is another practice which leads to the same outputs. Compared to Start At The End, Impact Mapping produces a higher fidelity understanding of the domain, but at the cost of increased complexity for facilitation. Generally speaking, Impact Mapping is the better fit when building products or services, and Start At The End is a better fit when discussing organizational change or other generally nebulous efforts.
+- [Start At The End](/practice/start-at-the-end/) is another practice which leads to the same outputs. Compared to Start At The End, Impact Mapping produces a higher fidelity understanding of the domain, but at the cost of increased complexity for facilitation. Generally speaking, Impact Mapping is the better fit when building products or services, and Start At The End is a better fit when discussing organizational change or other generally nebulous efforts.
 
 
 ## Who do you need?
@@ -42,7 +42,7 @@ Impact Mapping is an engaging, graphical, strategic planning technique. It was i
 
 For the shortened variation:
 
-- 2-4 hours of prep to establish a [goal or problem statement](/practices/why-is-defined/) _before_ the session. This is important, or your session will go sideways!
+- 2-4 hours of prep to establish a [goal or problem statement](/practice/why-is-defined/) _before_ the session. This is important, or your session will go sideways!
 - optionally - 2 hours before the session to create an outline of the Impact Map based on your current understanding, as a way to introduce the subject to participants
 - ~4 Hours to facilitate the session, not including breaks
 - Facilitate in small sessions @ around 60-90 minutes each

--- a/content/practice/retrospectives.md
+++ b/content/practice/retrospectives.md
@@ -21,14 +21,14 @@ Retrospectives facilitate continous improvement. Rather than wait until the end 
 
 Many practices benefit from their artefacts being re-visited, reflected upon and/or updated during retrospectives including:
 
-- [Social Contract](/practices/social-contract/)
-- [Team Sentiment](/practices/team-sentiment/)
-- [Burndown Charts](/practices/burndown/)
-- [Visualisation of Work](/practices/visualisation-of-work/)
+- [Social Contract](/practice/social-contract/)
+- [Team Sentiment](/practice/team-sentiment/)
+- [Burndown Charts](/practice/burndown/)
+- [Visualisation of Work](/practice/visualisation-of-work/)
 
 Engineering practices such as Continuous Integration and Test Automation can also benefit from being considered during retrospectives. In particular, exporting data from associated tools to give teams the opportunity for the team to review the data, inspect trends and establish whether any adaption in behaviour or practice would enable them and measurements to improve.
 
-The [Realtime-Retrospective](/practices/realtime-retrospective/) is a very similar practice which runs continiously and captured fe edback in real time.
+The [Realtime-Retrospective](/practice/realtime-retrospective/) is a very similar practice which runs continiously and captured fe edback in real time.
 
 
 ## Who do you need?

--- a/content/practice/social-contract.md
+++ b/content/practice/social-contract.md
@@ -31,7 +31,7 @@ To effectively use this practice you should look to create the following outcome
 
 - Collaborative Face Drawing[<sup>1</sup>](#footnote-1) is a great ice breaker or after lunch activity. Your Social Contract can be a nicely decorated with the faces of the team to show their commitment to the contract.
 - Working Agreements[<sup>2</sup>](#footnote-2) are a form of social contract often used to help establish behavioral standards between peers on a team. This is a great alternative if you do not have stakeholders or sponsors buying in to a Social Contract.
-- Use [retrospectives](/practices/retrospectives/) as a tool to revisit and update Social Contract based on learnings of team members working with each other
+- Use [retrospectives](/practice/retrospectives/) as a tool to revisit and update Social Contract based on learnings of team members working with each other
 
 ## Who do you need?
 

--- a/content/practice/start-at-the-end.md
+++ b/content/practice/start-at-the-end.md
@@ -18,14 +18,14 @@ Start At The End is a simple exercise to identify a set of assumptions which mus
 
 ## Why use Start At The End?
 
-- Most planning activities revolve around juggling a "shopping list of features," as Gojko Adzic calls them in [Impact Mapping](/practices/impact-mapping/). Even though the features are delivered, often the business objective is not achieved. Start At The End gives us a light weight approach to put the business value at the center of our work and make sure that assumptions that could lead to failure are clearly identified for examination 
+- Most planning activities revolve around juggling a "shopping list of features," as Gojko Adzic calls them in [Impact Mapping](/practice/impact-mapping/). Even though the features are delivered, often the business objective is not achieved. Start At The End gives us a light weight approach to put the business value at the center of our work and make sure that assumptions that could lead to failure are clearly identified for examination 
 - Start At The End is really easy and quick to facilitate, but often yields great results. It's a great technique for those new to facilitating workshops or sessions that are short on time.
 - The technique forces participants to think about failure, which many teams never do. It's surprising how much you can learn about a domain just by getting participants to share their fears. 
 - It's easy to communicate the results of the session in slide ware and project rooms. We'd recommend keeping the results up in the project space throughout your effort.
 
 ## Related Practices
 
-- [Impact Mapping](/practices/impact-mapping/) is another practice which leads to the same outputs. Compared to Start At The End, Impact Mapping produces a higher fidelity understanding of the domain, but at the cost of increased complexity for facilitation. Generally speaking, Impact Mapping is the better fit when building products or services, and Start At The End is a better fit when discussing organizational change or other generally nebulous efforts. 
+- [Impact Mapping](/practice/impact-mapping/) is another practice which leads to the same outputs. Compared to Start At The End, Impact Mapping produces a higher fidelity understanding of the domain, but at the cost of increased complexity for facilitation. Generally speaking, Impact Mapping is the better fit when building products or services, and Start At The End is a better fit when discussing organizational change or other generally nebulous efforts. 
 
 ## Who do you need?
 

--- a/content/practice/team-sentiment.md
+++ b/content/practice/team-sentiment.md
@@ -21,9 +21,9 @@ Team sentiment practices are often introduced where there is a strong sense of s
 
 ## Related Practices
 
-Where the team has used the [Social Contract](/practices/social-contract/) practice, team sentiment practices can help enforce some of the feeling radiated in the Social Contract.
+Where the team has used the [Social Contract](/practice/social-contract/) practice, team sentiment practices can help enforce some of the feeling radiated in the Social Contract.
 
-[Retrospectives](/practices/realtime-retrospective/) are excellent check-points on the team health and taking the opportunity to review the Team Sentiment artefcts can facilitate a team conversation as to how they can improve overall team mood and what has been learned in the recent iteration.
+[Retrospectives](/practice/realtime-retrospective/) are excellent check-points on the team health and taking the opportunity to review the Team Sentiment artefcts can facilitate a team conversation as to how they can improve overall team mood and what has been learned in the recent iteration.
 
 
 ## Who do you need?

--- a/content/practice/user-story-mapping.md
+++ b/content/practice/user-story-mapping.md
@@ -25,7 +25,7 @@ User Story Mapping is an evolution of the traditional Agile backlog, made popula
 
 ## Related Practices
 
-- User Story Mapping is a great way to create an Agile delivery plan for a business process designed with [Event Storming](/practices/event-storming/)
+- User Story Mapping is a great way to create an Agile delivery plan for a business process designed with [Event Storming](/practice/event-storming/)
 - Program Increment Planning[<sup>2</sup>](#footnote-2) in Scaled Agile Framework leverages many of the ideas behind User Story Mapping
 - Site Mapping[<sup>3</sup>](#footnote-3) should provide the backbone of the User Story Map in UI driven projects
 

--- a/content/practice/visualisation-of-work.md
+++ b/content/practice/visualisation-of-work.md
@@ -29,20 +29,20 @@ Where important information is constantly accessible and visible to people, both
 
 Practices we use that result in information radiators which we use to visualise work include:
 
-- [Impact Mapping](/practices/impact-mapping/)
-- [Event Storming](/practices/event-storming/)
-- [Value Stream Mapping and Metric Based Process Mapping](/practices/vsm-and-mbpm/)
+- [Impact Mapping](/practice/impact-mapping/)
+- [Event Storming](/practice/event-storming/)
+- [Value Stream Mapping and Metric Based Process Mapping](/practice/vsm-and-mbpm/)
 - Target Outcomes
-- [Social Contact](/practices/social-contract/)
-- [User Story Mapping](/practices/user-story-mapping/)
+- [Social Contact](/practice/social-contract/)
+- [User Story Mapping](/practice/user-story-mapping/)
 - Product Backlogs
 - Sprint Boards
-- [Burndown](/practices/burndown/) and Burnup Charts
+- [Burndown](/practice/burndown/) and Burnup Charts
 - Build Monitors
 - CI/CD monitors
 - Retrospectives
-- [Realtime Retrospective](/practices/realtime-retrospective/)
-- [Team Sentiment](/practices/team-sentiment/)
+- [Realtime Retrospective](/practice/realtime-retrospective/)
+- [Team Sentiment](/practice/team-sentiment/)
 
 
 ## Who do you need?

--- a/content/practice/vsm-and-mbpm.md
+++ b/content/practice/vsm-and-mbpm.md
@@ -22,10 +22,6 @@ Being derived from Lean Manufacturing, VSM & MBPM visually represent the way wor
 - formulating specific, data driven improvement plans
 - preventing "improvement" work in a particular area that leads to sub-optimization for the entire value stream / process
 
-## Related Practices
-
-- In order to effectively deliver a session, it's critical you prepare with a [Chartering](/routes/chartering/) exercise
-
 ## Who do you need?
 
 - No more than 10 people


### PR DESCRIPTION
**What issue does this PR solve?**
Resolves #285 

**Explain the problem and the proposed solution**
We updated `practices` to be `practice` in our page types and paths, which caused existing links to `practices` to break. Updating those links to use `practice` fixed the problem.

I also removed a link to "chartering", which was removed a while back when we got rid of Waypoints.