### PR TITLE
set max height to chop images to big for page

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -200,6 +200,8 @@ p.social-subtitle {
   width: 100%;
   transition: opacity 0.5s;
   opacity: 1;
+  max-height: 17rem;
+  object-fit: cover;
 }
 
 .tile:hover .tile-img {
@@ -434,7 +436,8 @@ a:focus {
 
 .jumbotron-img {
   width: 100%;
-  height: auto;
+  max-height: 55rem;
+  object-fit: cover;
 }
 
 /* =Search */


### PR DESCRIPTION
**What issue does this PR solve?**
Resolves #308
**Explain the problem and the proposed solution**
Over flow of image is chopped off using object fit. This applies to the tiles and the jumbotron image