### PR TITLE
Remove Netlify CMS stylesheets

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -4,20 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Content Manager</title>
-
-  <!-- Include the styles for the Netlify CMS UI, after your own styles -->
-  <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.css" />
-
   <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-
-  <style>
-    /* remove the publish button from the editorial_workflow to avoid user confusion */
-    .nc-entryEditor-toolbar-publishButton,
-    .nc-entryEditor-toolbar-statusPublished,
-    .nc-workflow-card-buttonPublish {
-        display: none !important;
-    }
-  </style>
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->


### PR DESCRIPTION
**What issue does this PR solve?**
This helps move towards #349 but does not resolve it.

**Explain the problem and the proposed solution**
We still have styles for 1.0, even though 2.0 moved to inline styles. This is confusing and slows down page loads. Solution: remove the 1.0 styles (which don't do anything now) as well as the styles to hide the publish button (which don't work with 2.0).