### PR TITLE
Update reporting email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -56,7 +56,7 @@ further defined and clarified by project maintainers.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported by contacting the project team at 
-[rhc-open-innovation-labs@redhat.com](mailto:rhc-open-innovation-labs@redhat.com). 
+[report@openpracticelibrary.com](mailto:report@openpracticelibrary.com). 
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
**What issue does this PR solve?**
Adds the reporting email address proposed in #176

**Explain the problem and the proposed solution**
- @mtakane set up a forwarding address using forwardmx.io, and I set up the appropriate DNS records in Netlify DNS. We then confirmed that emails actually made it through to Matt.

Before we merge, we should:
- Change the password on the forwardmx.io account
- Securely share the password with the maintainers/moderators
- Update the forwarding destination to include preferred email addresses for the moderators (right now it's just Matt's personal email).
- Do one final test to ensure that everyone on the list receives emails sent to that address.