### PR TITLE
add preview template for practice collection

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -9,5 +9,12 @@
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/cms.js"></script>
+  <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="previews.js" type="text/babel"></script>
+  <script>
+    CMS.registerPreviewStyle('/css/screen.css');
+    CMS.registerPreviewStyle('/css/custom.css');
+  </script>
 </body>
 </html>

--- a/static/admin/previews.js
+++ b/static/admin/previews.js
@@ -1,0 +1,66 @@
+const Jumbotron = ({ data }) => (
+  <div class="jumbotron">
+    <img class="jumbotron-img" src={data.jumbotron} alt={data.jumbotronAlt}/>
+  </div>
+)
+
+const Header = ({ data }) => (
+  <header class="post-header">
+    <section class="article-heading">
+      <div class="inline-block">
+        <h2 class="practice-title">{data.title}</h2>
+        {data.subtitle ? <p class="practice-subtitle fix-width">{data.subtitle}</p> : null}
+      </div>
+      <div class="inline-block mobius-loop-position">
+        <img
+          class="loop-img"
+          src={`/images/loop-positions/${data.area}.svg`}
+          alt={`${data.area} loop position`}
+        />
+      </div>
+    </section>
+    {data.jumbotron ? <Jumbotron data={data}/> : null}
+  </header>
+)
+
+const HowToItem = ({ icon, label, value }) => (
+  <div class="how-to-box-item">
+    <div class={`icon-${icon} how-to-box-icon`}></div>
+    <p class="how-to-box-text">
+      <i>{label}</i>
+    </p>
+    <p class="how-to-box-text">{value}</p>
+  </div>
+)
+
+const HowTo = ({ data }) => (
+  <div class="how-to-box">
+    <HowToItem icon="people" label="No. People" value={data.people}/>
+    <HowToItem icon="time" label="Time" value={data.time}/>
+    <HowToItem icon="stats" label="Difficulty" value={data.difficulty}/>
+    {data.participants
+      ? <HowToItem icon="speach" label="Participants" value={data.participants.join(', ')}/>
+      : null
+    }
+  </div>
+)
+
+
+const PracticePreview = ({ entry, widgetFor }) => {
+  const data = entry.get('data').toJS()
+  return (
+    <div>
+      <article class="post practice">
+        <Header data={data}/>
+        {data.people && data.time && data.difficulty ? <HowTo data={data}/> : null}
+        {widgetFor('body')}
+      </article>
+      <a class="tile">
+        <img class="tile-img" src={data.icon || '/images/stock-tiles/1.jpeg'} alt="hello!"/>
+        <h2 class="tile-heading">{data.title}</h2>
+      </a>
+    </div>
+  )
+}
+
+CMS.registerPreviewTemplate('practice', PracticePreview)


### PR DESCRIPTION
Hey folks - loving the project here, really glad you're using Netlify CMS for it! I took the liberty of creating a preview template for your Practice collection, hope it helps. Here's a [preview](https://deploy-preview-384--openpracticelibrary.netlify.com/admin/#/collections/practice/entries/agile-agenda).

Hopefully we can get a solution to the [media issue](https://github.com/netlify/netlify-cms/issues/1344#issuecomment-407560119) going soon 🤞

**What issue does this PR solve?**
When creating or editing a new Practice in the CMS, the preview pane is unstyled and doesn't reflect the actual output.

**Explain the problem and the proposed solution**
It's always helpful to see what the actual output is when editing content. For example, it may not be obvious which fields are necessary to make the How To box display, so the preview template now copies the site logic to only display the box when the site would.

This PR provides a React component that mimics the site's `practice` layout.

Note: I brought in standalone copies of React and Babel to allow JSX React templates to be written for the preview pane without impacting your build process. A site generally wouldn't take this approach in production, but I think it's a great approach for CMS purposes.

<img width="1427" alt="screen shot 2018-08-27 at 3 10 20 pm" src="https://user-images.githubusercontent.com/2112202/44680383-9a023c00-aa0b-11e8-988b-8c7abc982118.png">
