### PR TITLE
Fix back button on search

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -22,6 +22,10 @@ searchbutton.onclick = function () {
 	runQuery(searchfield.value);
 };
 
+window.addEventListener('popstate', function() {
+	this.window.location.reload();
+});
+
 const runQuery = function (searchTerm) {
 	var cleanedResults = "";
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -18,14 +18,11 @@ searchfield.addEventListener("keyup", function (event) {
 });
 
 searchbutton.onclick = function () {
-	window.history.replaceState(null, null, "/search/?search=" + searchfield.value);
+	window.history.pushState(null, null, "/search/?search=" + searchfield.value);
 	runQuery(searchfield.value);
 };
 
 const runQuery = function (searchTerm) {
-	// var url = new URL(window.location.href);
-	// var searchTerm = url.searchParams.get('search');
-
 	var cleanedResults = "";
 
 	let RESULTS = document.getElementById("results-wrapper");


### PR DESCRIPTION
**What issue does this PR solve?**
Resolves #364 

**Explain the problem and the proposed solution**
Problem: When you search for something, the back button doesn't take you from the search results to the previous page.
Solution: Use `pushState` instead of `replaceState`.