### PR TITLE
Make it easier to contribute.

### DIFF
--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -25,6 +25,8 @@
         {{ $practiceMap.Add .Params.area (slice $currentItem) }}
       {{end}}
 
+      {{ partial "button.html" (dict "absolutePath" "/admin/#/collections/practice/new" "buttonText" "Add new practice") }}
+
       <section class="loop-categories">
           <a name="discovery-loop-outcomes"></a><a name="discovery-loop-why"></a>
           <h2>Discovery</h2>
@@ -79,8 +81,7 @@
             {{ partial "tile.html" . }}
           {{end}}
         </div>
-      
+
       </section>
 
-      {{ partial "button.html" (dict "absolutePath" "/admin/#/collections/practice/new" "buttonText" "Add new practice") }}
     </div>


### PR DESCRIPTION
Signed-off-by: Clement Verna <cverna@tutanota.com>

**What issue does this PR solve?**
Currently it is difficult to find the button to add a new practice, this button is place at the bottom of the page.

**Explain the problem and the proposed solution**
This commit move the `Add new practice` button to the top of the
page bellow the `Our Mission` statement. This will make it easier for new contributor to contribute.