### PR TITLE
Make perspective field optional

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,13 +25,13 @@ collections:
           {label: "Delivery - Measure & Learn", value: "delivery-measure-and-learn"},
           {label: "Foundation - Culture & Collaboration", value: "foundation-culture-and-collaboration"},
           {label: "Foundation - Technical",  value: "foundation-technical"}]}
-      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: []}
+      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: [], required: false}
       - {label: "Tile icon", name: "icon", hint: "Icon to be used on the home screen and cards for the practice", widget: "image", required: false}
       - {label: "Jumbotron image", hint: "Large full width image for under the titles", name: "jumbotron", widget: "image", required: false}
       - {label: "Jumbotron alt text", hint: "Accessible description of the image for screen readers", name: "jumbotronAlt", widget: "string", required: false}
       - {label: "No. of people required", hint: "How many people are needed for the practice eg 2+ or 10", name: "people", widget: "string", required: false}
       - {label: "Time length", hint: "How long is needed to facilitate this practice", name: "time", widget: "string", required: false}
-      - {label: "Facilitation difficulty", hint: "How difficult is it to facilitate this practice", name: "difficulty", widget: "select", required: false, options:
+      - {label: "Facilitation difficulty", hint: "How difficult is it to facilitate this practice", name: "difficulty", widget: "select",, options:
           [{label: "Easy", value: "easy"},
           {label: "Moderate", value: "moderate"},
           {label: "Hard", value: "hard"}]}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,7 +25,7 @@ collections:
           {label: "Delivery - Measure & Learn", value: "delivery-measure-and-learn"},
           {label: "Foundation - Culture & Collaboration", value: "foundation-culture-and-collaboration"},
           {label: "Foundation - Technical",  value: "foundation-technical"}]}
-      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: []}
+      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: [], required: false}
       - {label: "Tile icon", name: "icon", hint: "Icon to be used on the home screen and cards for the practice", widget: "image", required: false}
       - {label: "Jumbotron image", hint: "Large full width image for under the titles", name: "jumbotron", widget: "image", required: false}
       - {label: "Jumbotron alt text", hint: "Accessible description of the image for screen readers", name: "jumbotronAlt", widget: "string", required: false}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -25,13 +25,13 @@ collections:
           {label: "Delivery - Measure & Learn", value: "delivery-measure-and-learn"},
           {label: "Foundation - Culture & Collaboration", value: "foundation-culture-and-collaboration"},
           {label: "Foundation - Technical",  value: "foundation-technical"}]}
-      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: [], required: false}
+      - {label: "Related Perspectives", hint: "Comma-separated list of slugs e.g., domain-driven-design, product-ownership", name: "perspectives", widget: "list", default: []}
       - {label: "Tile icon", name: "icon", hint: "Icon to be used on the home screen and cards for the practice", widget: "image", required: false}
       - {label: "Jumbotron image", hint: "Large full width image for under the titles", name: "jumbotron", widget: "image", required: false}
       - {label: "Jumbotron alt text", hint: "Accessible description of the image for screen readers", name: "jumbotronAlt", widget: "string", required: false}
       - {label: "No. of people required", hint: "How many people are needed for the practice eg 2+ or 10", name: "people", widget: "string", required: false}
       - {label: "Time length", hint: "How long is needed to facilitate this practice", name: "time", widget: "string", required: false}
-      - {label: "Facilitation difficulty", hint: "How difficult is it to facilitate this practice", name: "difficulty", widget: "select",, options:
+      - {label: "Facilitation difficulty", hint: "How difficult is it to facilitate this practice", name: "difficulty", widget: "select", required: false, options:
           [{label: "Easy", value: "easy"},
           {label: "Moderate", value: "moderate"},
           {label: "Hard", value: "hard"}]}


### PR DESCRIPTION
**What issue does this PR solve?**
Right now, perspective is a mandatory field. There are only two perspectives, so there are plenty of practices that don't have a corresponding perspective. It's not possible to edit such practices without adding an unnecessary perspective. This came up in #534.

**Explain the problem and the proposed solution**
Add `required: false` to the config for this field.