### PR TITLE
Reorganize and expand contributing guide

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -21,7 +21,7 @@ customCSS = [
 
 [[menu.main]]
   name = "Perspectives"
-  weight = 3
+  weight = 6
   identifier = "Perspectives"
   url = "/perspective/"
 

--- a/config.toml
+++ b/config.toml
@@ -19,9 +19,6 @@ customCSS = [
   "https://fonts.googleapis.com/css?family=Arimo:400,700"
 ]
 
-[permalinks]
-page = "/:slug/"
-
 [[menu.main]]
   name = "Perspectives"
   weight = 3

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -21,9 +21,6 @@ Describe how people in this community use practices to accomplish engagement suc
 #### Search with Intent
 Share details about a particular practice that community members use, learn perspectives on a particular practice and why practices are used, pointers on how to facilitate it, and when it should be employed.
 
-## What This Library *Is*
-Just enough information for each practice to "specify the end state, its purpose, and the minimum possible constraints" in order to "create alignment and enable autonomy" for participants and facilitators. Where more detailed content is useful, we'll provide links. This idea comes from Donald Reinersten's *Principle of Mission*, which provides the conceptual foundation to *Lean Enterprise* by Jez Humble, Joanne Molesky & Barry O'Reilly.
-
 ## How to Fit These Practices into Your Existing Approach
 While everybody has their approach to engagements, there is a need to identify particular outcomes that common practices look to accomplish.
 

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -7,7 +7,7 @@ authors:
   - mtakane
 date: 2017-10-19T21:03:59.000Z
 menu: main
-weight: 4
+weight: 3
 aliases:
   /about/
 ---

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -8,6 +8,8 @@ authors:
 date: 2017-10-19T21:03:59.000Z
 menu: main
 weight: 4
+aliases:
+  /about/
 ---
 
 ## Goals of this Library

--- a/content/page/about.md
+++ b/content/page/about.md
@@ -24,23 +24,6 @@ Share details about a particular practice that community members use, learn pers
 ## What This Library *Is*
 Just enough information for each practice to "specify the end state, its purpose, and the minimum possible constraints" in order to "create alignment and enable autonomy" for participants and facilitators. Where more detailed content is useful, we'll provide links. This idea comes from Donald Reinersten's *Principle of Mission*, which provides the conceptual foundation to *Lean Enterprise* by Jez Humble, Joanne Molesky & Barry O'Reilly.
 
-## What A Practice *Is*
-A practice is an exercise or an approach that we propose the reader to apply systematically to achieve specific goals.
-Practices have the following important characteristics:
-- Structured (they consist of rigorously defined, often discrete and systematic steps)
-- Replicable (they're reproducible or repeatable across situations or contexts)
-- Learned (they're not innate but rather habituated—and thus teachable!)
-
-## Contributing
-
-We'd love to hear your thoughts about the material presented here or other content you'd like to add. [Open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) and we can go from there.
-
-Alternately, feel free to fork our [github repo](https://github.com/openpracticelibrary/openpracticelibrary) and submit a PR of your proposed changes. We use markdown files for our base content that gets rendered for this site. For helpful development setup see our [README](https://github.com/openpracticelibrary/openpracticelibrary/blob/master/README.md)
-
-## Style
-
-We're looking to be friendly and also authoritative, comprehensive and also concise. We use the active voice where possible to help guide teams to action. We don't always get it right, though. If you find something that could be clearer or punchier, feel free to send us a merge request!
-
 ## How to Fit These Practices into Your Existing Approach
 While everybody has their approach to engagements, there is a need to identify particular outcomes that common practices look to accomplish.
 
@@ -64,8 +47,6 @@ Practices are identified on one of areas of the canvas:
 6. The "Culture & Collaboration" area of the Foundation layer - Culture practices help provide the environment, establish team relationships, mindset and engagement to facilitate a smooth and continuous journey round Discovery and Delivery loops. Collaboration practices help facilitate conversation and alignment in a transparent and open manner facilitating successful Discovery and Delivery practices to be effective.
 
 7. The "Technical" area of the Foundation layer - Technical practices enable the successful continuous and sustainable delivery of value from teams working on the discovery and delivery loops above.
-
-
 
 ## Other Libraries That Inspired Us
 

--- a/content/page/cms.md
+++ b/content/page/cms.md
@@ -1,0 +1,135 @@
+---
+title: Using the CMS
+authors:
+  - rdebeasi
+  - springdo
+date: 2017-10-19T21:03:59.000Z
+menu: main
+weight: 0
+---
+
+# Netlify CMS Instructions
+
+This documentation covers using Netlify CMS to write content for the Open Practice Library. At a high level the workflow is fairly simple:
+
+1. On a practice page or the home page hit the `Improve` or `Add new` button to launch the CMS.
+1. Login with your GitHub Account. (If you don't have an account you can [create one here](https://github.com/join). Don't worry, it's free to create an account!)
+1. Once logged into the CMS, pick the `Practice` or `How To` guide you want to implement or improve.
+1. Update it with your changes and remember to append your `github` username to the end of the authors list.
+1. Make your changes and hit `Save`. The moderators will pick up the changes from there!
+
+For even more details on these, see the guides below for Content Writers and Content Moderators:
+
+---
+
+## Adding or updating practices (Content Writers)
+
+### Pre-requisites
+If you're new to the CMS and have not created content before; there are two things you need to do before creating content
+
+1. To create or edit a practice, you will need a [Github](https://github.com) account. You don't need to have any content in Github as it is only used for authentication purposes.
+2. With a Github account created [add your author information](https://openpracticelibrary.com/admin/#/collections/author/new) to the CMS by filling in the fields (only name and gitusername are mandatory). Hit save and this will create a Pull Request to add your author into the Git repository.
+![example-author](/images/contributing/author.png)
+
+### Creating Content
+
+_Before you continue, please check the Pre-Requisites above (for example, that you have a valid GitHub.com account)_
+
+We are using [Netlify CMS](https://www.netlifycms.org/) to update this content.
+
+- Visit <a target="" href="https://openpracticelibrary.com/admin/">Netifly Admin Page </a> and click "Login with Netifly Identity".
+- Select "Continue with GitHub" and enter your Github credentials.
+- Click "New Practices".
+- Fill in the Title with the name of your Practice and the subtitle with something catchy to describe your content. Leave the publish date as is.
+- To include a splash image for your practice add one to the Jumbotron
+- Add a tile icon image to the practice for it to appear on the homepage.
+- Add your `Github` username to the list of Authors to get a writers credit.
+- From the Mobius dropdown select where your article fits
+- You can either use Rich Text or Markdown format for the content.  Rich Text could be easier for non-technical people and you can use the style icons at the top of the Body section to add headers and formatting.
+
+Once you have added your content, click the blue "Save" button at the top of the screen.
+
+Change the Status to "In Review".
+
+This will raise a pull request on the underlying Github repository which can then be actioned by one of the site moderators.  
+
+<b>If you try to publish the Practice yourself, you will see an error as it needs to be curated by a moderator.</b>
+
+<b>You will receive emails once the content has been actioned. </b>
+
+These actions could be to add/change or content if everything is good, you will receive and email saying that the content has been merged (accepted in to the library).
+
+### Editing Content
+You can use the first steps in the above workflow to edit content.  Select the practice you wish edit.  Don't forget to update the date and click "Save" once you have edited the content.  
+
+An email will be sent to the moderators who will approve the change.
+
+#### Guidance for Content Writers
+
+##### A practice _must_ be
+
+- **Empowering** - It helps teams discover and deliver iteratively.
+- **Concise** - It can be read in a few minutes.
+- **Agnostic** - It doesn't require the team to follow a specific project management framework.
+- **Proven** - It has been tested in the real world by the practice author.
+
+##### A practice _should_ be
+
+- **Approachable** - It can be understood by someone who's not an expert in project management.
+- **Visual** - It includes images and videos.
+- **Accessible** - It includes alt text for images and captions for videos.
+- **Novel** - It isn't already covered by another practice.
+- **Deep** - It provides links to related resources, examples, and other materials for readers who want to explore further.
+
+A simple template is shown below which contains some example headers for use when creating a new `Practice` within the Library.
+
+|Header|Comment|
+|----------------|--------|
+|What is it?| A brief description of the practice|
+|Why use it?| A short paragraph describing the use case(s) for the use of this practice. |
+|How does it fit? | Relevant section(s) of the Open Practice Library for which this practice can be used|
+|Related Practices| Which practices can be used in conjunction, before or after this practice|
+
+If you are creating a `How to` or facilitation guide, some additional fields need to be filled out in the CMS such as the difficulty of the exercise and the people required to run the session. Some example headings for a How to guide should include, but are not limited to, the following
+
+|Header|Comment|
+|----------------|--------|
+|What is it?| A brief description of the practice|
+|Materials Needed|What materials are required to run the practice? For example, a large whiteboard, sticky notes, whiteboard markers etc|
+|Steps| Short, concise description of the things needed to accomplish the goal of the activity. Pictures and videos included in here will really help. |
+|Templates| Any reference material such as canvas or other printouts needed|
+|External Examples| Any external resources or use cases, blogs etc that can help learners who want to learn more|
+
+---
+
+## Publishing Content (Moderators)
+As a moderator, you will receive and email to say that new content has been added:
+<pre>
+Automatically generated by Netlify CMS
+You can view, comment on, or merge this pull request online at:
+  https://github.com/openpracticelibrary/practice-library/pull/9
+Commit Summary
+    Create Practices “chrisj-test-of-workflow”
+File Changes
+    A content/practices/chrisj-test-of-workflow.md (5)
+Patch Links:
+    https://github.com/openpracticelibrary/practice-library/pull/9.patch
+    https://github.com/openpracticelibrary/practice-library/pull/9.diff
+—
+You are receiving this because you are subscribed to this thread.
+Reply to this email directly, view it on GitHub, or mute the thread.
+</pre>
+
+### Steps to fix
+ - Go to the [Pull Request Page](https://github.com/openpracticelibrary/practice-library/pulls) and click on the relevant pull request or follow the link in the email.  
+ - To see what has been added / changed, go to the "Files changed" tab.
+ - If you require more information or would like changed to be made, write the comment in the "Leave a Comment" box.  
+
+_Note: Add @username in the comment so the originator receives the email.  The originators user name can be found in the "Commits" tab._
+
+ - If you are happy with the content and there are no conflicts, click the "Merge pull Request" button followed by the "Confirm Merge" button.  Add some additional comments if required.
+ - Once merged, delete the branch (this will hopefully be automated at some point) as there is an issue with the CMS that does not allow people to create further edits while it still exists. <b>Click the "Delete Branch" button on the PR's page.</b>
+ - This act will deploy the changes to the `staging` environment. To deploy the change to the main site, raise a PR from `staging` to `master`. On GitHub, navigate to the `staging` branch which should be ahead of `master` and hit raise PR. Merge the change set as you did before.
+ - If you go back to the [List of Practices](https://openpracticelibrary.com/admin/#/collections/practices) you should see the newly added practice.
+
+ <i>Note: The order is a little quirky at the moment - not sure why.  It's mainly alphabetical with a few exceptions.</i>

--- a/content/page/cms.md
+++ b/content/page/cms.md
@@ -64,21 +64,6 @@ An email will be sent to the moderators who will approve the change.
 
 #### Guidance for Content Writers
 
-##### A practice _must_ be
-
-- **Empowering** - It helps teams discover and deliver iteratively.
-- **Concise** - It can be read in a few minutes.
-- **Agnostic** - It doesn't require the team to follow a specific project management framework.
-- **Proven** - It has been tested in the real world by the practice author.
-
-##### A practice _should_ be
-
-- **Approachable** - It can be understood by someone who's not an expert in project management.
-- **Visual** - It includes images and videos.
-- **Accessible** - It includes alt text for images and captions for videos.
-- **Novel** - It isn't already covered by another practice.
-- **Deep** - It provides links to related resources, examples, and other materials for readers who want to explore further.
-
 A simple template is shown below which contains some example headers for use when creating a new `Practice` within the Library.
 
 |Header|Comment|

--- a/content/page/cms.md
+++ b/content/page/cms.md
@@ -4,8 +4,6 @@ authors:
   - rdebeasi
   - springdo
 date: 2017-10-19T21:03:59.000Z
-menu: main
-weight: 0
 ---
 
 # Netlify CMS Instructions

--- a/content/page/cms.md
+++ b/content/page/cms.md
@@ -6,8 +6,6 @@ authors:
 date: 2017-10-19T21:03:59.000Z
 ---
 
-# Netlify CMS Instructions
-
 This documentation covers using Netlify CMS to write content for the Open Practice Library. At a high level the workflow is fairly simple:
 
 1. On a practice page or the home page hit the `Improve` or `Add new` button to launch the CMS.

--- a/content/page/contribute.md
+++ b/content/page/contribute.md
@@ -1,5 +1,5 @@
 ---
-title: Contribution Guide
+title: Contributing
 authors:
   - rdebeasi
   - springdo
@@ -8,72 +8,29 @@ menu: main
 weight: 0
 ---
 
-# Netlify CMS Instructions
+Welcome! Thank you for taking the time to contribute. This project relies on an active and involved community, and we really appreciate your support.
 
-This documentation covers using Netlify CMS to write content for the Open Practice Library. At a high level the workflow is fairly simple:
+## Code of Conduct
 
-1. On a practice page or the home page hit the `Improve` or `Add new` button to launch the CMS.
-1. Login with your GitHub Account. (If you don't have an account you can [create one here](https://github.com/join). Don't worry, it's free to create an account!)
-1. Once logged into the CMS, pick the `Practice` or `How To` guide you want to implement or improve.
-1. Update it with your changes and remember to append your `github` username to the end of the authors list.
-1. Make your changes and hit `Save`. The moderators will pick up the changes from there!
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be reported by contacting the project team at
+[rhc-open-innovation-labs@redhat.com](mailto:rhc-open-innovation-labs@redhat.com).
 
-For even more details on these, see the guides below for Content Writers and Content Moderators:
+## How to contribute
 
----
+To contribute content, [log into the CMS](/admin/) or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Using the CMS](/cms/) and the content guidelines below.
 
-## Adding or updating practices (Content Writers)
+To learn more about contributing code, see [DEVELOPING.md](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/DEVELOPING.md).
 
-### Pre-requisites
-If you're new to the CMS and have not created content before; there are two things you need to do before creating content
+## What to contribute
 
-1. To create or edit a practice, you will need a [Github](https://github.com) account. You don't need to have any content in Github as it is only used for authentication purposes.
-2. With a Github account created [add your author information](https://openpracticelibrary.com/admin/#/collections/author/new) to the CMS by filling in the fields (only name and gitusername are mandatory). Hit save and this will create a Pull Request to add your author into the Git repository.
-![example-author](/images/contributing/author.png)
-
-### Creating Content
-
-_Before you continue, please check the Pre-Requisites above (for example, that you have a valid GitHub.com account)_
-
-We are using [Netlify CMS](https://www.netlifycms.org/) to update this content.
-
-- Visit <a target="" href="https://openpracticelibrary.com/admin/">Netifly Admin Page </a> and click "Login with Netifly Identity".
-- Select "Continue with GitHub" and enter your Github credentials.
-- Click "New Practices".
-- Fill in the Title with the name of your Practice and the subtitle with something catchy to describe your content. Leave the publish date as is.
-- To include a splash image for your practice add one to the Jumbotron
-- Add a tile icon image to the practice for it to appear on the homepage.
-- Add your `Github` username to the list of Authors to get a writers credit.
-- From the Mobius dropdown select where your article fits
-- You can either use Rich Text or Markdown format for the content.  Rich Text could be easier for non-technical people and you can use the style icons at the top of the Body section to add headers and formatting.
-
-Once you have added your content, click the blue "Save" button at the top of the screen.
-
-Change the Status to "In Review".
-
-This will raise a pull request on the underlying Github repository which can then be actioned by one of the site moderators.  
-
-<b>If you try to publish the Practice yourself, you will see an error as it needs to be curated by a moderator.</b>
-
-<b>You will receive emails once the content has been actioned. </b>
-
-These actions could be to add/change or content if everything is good, you will receive and email saying that the content has been merged (accepted in to the library).
-
-### Editing Content
-You can use the first steps in the above workflow to edit content.  Select the practice you wish edit.  Don't forget to update the date and click "Save" once you have edited the content.  
-
-An email will be sent to the moderators who will approve the change.
-
-#### Guidance for Content Writers
-
-##### A practice _must_ be
+### A practice _must_ be
 
 - **Empowering** - It helps teams discover and deliver iteratively.
 - **Concise** - It can be read in a few minutes.
 - **Agnostic** - It doesn't require the team to follow a specific project management framework.
 - **Proven** - It has been tested in the real world by the practice author.
 
-##### A practice _should_ be
+### A practice _should_ be
 
 - **Approachable** - It can be understood by someone who's not an expert in project management.
 - **Visual** - It includes images and videos.
@@ -81,55 +38,10 @@ An email will be sent to the moderators who will approve the change.
 - **Novel** - It isn't already covered by another practice.
 - **Deep** - It provides links to related resources, examples, and other materials for readers who want to explore further.
 
-A simple template is shown below which contains some example headers for use when creating a new `Practice` within the Library.
+## Gathering Feedback
 
-|Header|Comment|
-|----------------|--------|
-|What is it?| A brief description of the practice|
-|Why use it?| A short paragraph describing the use case(s) for the use of this practice. |
-|How does it fit? | Relevant section(s) of the Open Practice Library for which this practice can be used|
-|Related Practices| Which practices can be used in conjunction, before or after this practice|
+As a community, we strive to provide kind and constructive feedback on your PR.
 
-If you are creating a `How to` or facilitation guide, some additional fields need to be filled out in the CMS such as the difficulty of the exercise and the people required to run the session. Some example headings for a How to guide should include, but are not limited to, the following
+If a pull request doesn't meet the "must be" guidelines, we may ask that the practice be updated before it's merged. If a pull request doesn't meet the "should be" guidelines, we may merge the pull request and add an issue for future improvements to the practice.
 
-|Header|Comment|
-|----------------|--------|
-|What is it?| A brief description of the practice|
-|Materials Needed|What materials are required to run the practice? For example, a large whiteboard, sticky notes, whiteboard markers etc|
-|Steps| Short, concise description of the things needed to accomplish the goal of the activity. Pictures and videos included in here will really help. |
-|Templates| Any reference material such as canvas or other printouts needed|
-|External Examples| Any external resources or use cases, blogs etc that can help learners who want to learn more|
-
----
-
-## Publishing Content (Moderators)
-As a moderator, you will receive and email to say that new content has been added:
-<pre>
-Automatically generated by Netlify CMS
-You can view, comment on, or merge this pull request online at:
-  https://github.com/openpracticelibrary/practice-library/pull/9
-Commit Summary
-    Create Practices “chrisj-test-of-workflow”
-File Changes
-    A content/practices/chrisj-test-of-workflow.md (5)
-Patch Links:
-    https://github.com/openpracticelibrary/practice-library/pull/9.patch
-    https://github.com/openpracticelibrary/practice-library/pull/9.diff
-—
-You are receiving this because you are subscribed to this thread.
-Reply to this email directly, view it on GitHub, or mute the thread.
-</pre>
-
-### Steps to fix
- - Go to the [Pull Request Page](https://github.com/openpracticelibrary/practice-library/pulls) and click on the relevant pull request or follow the link in the email.  
- - To see what has been added / changed, go to the "Files changed" tab.
- - If you require more information or would like changed to be made, write the comment in the "Leave a Comment" box.  
-
-_Note: Add @username in the comment so the originator receives the email.  The originators user name can be found in the "Commits" tab._
-
- - If you are happy with the content and there are no conflicts, click the "Merge pull Request" button followed by the "Confirm Merge" button.  Add some additional comments if required.
- - Once merged, delete the branch (this will hopefully be automated at some point) as there is an issue with the CMS that does not allow people to create further edits while it still exists. <b>Click the "Delete Branch" button on the PR's page.</b>
- - This act will deploy the changes to the `staging` environment. To deploy the change to the main site, raise a PR from `staging` to `master`. On GitHub, navigate to the `staging` branch which should be ahead of `master` and hit raise PR. Merge the change set as you did before.
- - If you go back to the [List of Practices](https://openpracticelibrary.com/admin/#/collections/practices) you should see the newly added practice.
-
- <i>Note: The order is a little quirky at the moment - not sure why.  It's mainly alphabetical with a few exceptions.</i>
+Again, thank you so much for your interest and support! We look forward to enhancing the Open Practice Library.

--- a/content/page/contribute.md
+++ b/content/page/contribute.md
@@ -12,36 +12,15 @@ Welcome! Thank you for taking the time to contribute. This project relies on an 
 
 ## Code of Conduct
 
-This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be reported by contacting the project team at
-[rhc-open-innovation-labs@redhat.com](mailto:rhc-open-innovation-labs@redhat.com).
+This project is governed by our [Code of Conduct](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be reported by contacting the project team at
+[report@openpracticelibrary.com](mailto:report@openpracticelibrary.com).
 
-## How to contribute
+## Contributing
 
-To contribute content, [log into the CMS](/admin/) or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Using the CMS](/cms/) and the content guidelines below.
+To let us know about something that you'd like to see added or improved [open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) on GitHub.
+
+To contribute content, [log into the CMS](/admin/), or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Editorial Style](/editorial/) and [Using the CMS](/cms/).
 
 To learn more about contributing code, see [DEVELOPING.md](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/DEVELOPING.md).
 
-## What to contribute
-
-### A practice _must_ be
-
-- **Empowering** - It helps teams discover and deliver iteratively.
-- **Concise** - It can be read in a few minutes.
-- **Agnostic** - It doesn't require the team to follow a specific project management framework.
-- **Proven** - It has been tested in the real world by the practice author.
-
-### A practice _should_ be
-
-- **Approachable** - It can be understood by someone who's not an expert in project management.
-- **Visual** - It includes images and videos.
-- **Accessible** - It includes alt text for images and captions for videos.
-- **Novel** - It isn't already covered by another practice.
-- **Deep** - It provides links to related resources, examples, and other materials for readers who want to explore further.
-
-## Gathering Feedback
-
-As a community, we strive to provide kind and constructive feedback on your PR.
-
-If a pull request doesn't meet the "must be" guidelines, we may ask that the practice be updated before it's merged. If a pull request doesn't meet the "should be" guidelines, we may merge the pull request and add an issue for future improvements to the practice.
-
-Again, thank you so much for your interest and support! We look forward to enhancing the Open Practice Library.
+We look forward to working together to move the Open Practice Library forward!

--- a/content/page/contributing.md
+++ b/content/page/contributing.md
@@ -21,7 +21,7 @@ This project is governed by our [Code of Conduct](https://github.com/openpractic
 
 To let us know about something that you'd like to see added or improved, [open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) on GitHub.
 
-To contribute content, [log into the CMS](/admin/), or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Editorial Style](/editorial/) and [Using the CMS](/cms/).
+To contribute content, [log into the CMS](/admin/), or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Editorial Style](/page/editorial/) and [Using the CMS](/page/cms/).
 
 To learn more about contributing code, see [DEVELOPING.md](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/DEVELOPING.md).
 

--- a/content/page/contributing.md
+++ b/content/page/contributing.md
@@ -7,7 +7,7 @@ date: 2017-10-19T21:03:59.000Z
 menu: main
 weight: 5
 aliases:
-  - /contributing/
+  - /contribution-guide/
 ---
 
 Welcome! Thank you for taking the time to contribute. This project relies on an active and involved community, and we really appreciate your support.

--- a/content/page/contributing.md
+++ b/content/page/contributing.md
@@ -17,9 +17,9 @@ Welcome! Thank you for taking the time to contribute. This project relies on an 
 This project is governed by our [Code of Conduct](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be reported by contacting the project team at
 [report@openpracticelibrary.com](mailto:report@openpracticelibrary.com).
 
-## Contributing
+## Getting Started
 
-To let us know about something that you'd like to see added or improved [open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) on GitHub.
+To let us know about something that you'd like to see added or improved, [open an issue](https://github.com/openpracticelibrary/openpracticelibrary/issues) on GitHub.
 
 To contribute content, [log into the CMS](/admin/), or click the "add new practice" or "improve this practice" buttons throughout the site. For more information, see [Editorial Style](/editorial/) and [Using the CMS](/cms/).
 

--- a/content/page/contributing.md
+++ b/content/page/contributing.md
@@ -25,4 +25,4 @@ To contribute content, [log into the CMS](/admin/), or click the "add new practi
 
 To learn more about contributing code, see [DEVELOPING.md](https://github.com/openpracticelibrary/openpracticelibrary/blob/staging/DEVELOPING.md).
 
-We look forward to working together to move the Open Practice Library forward!
+We look forward to working with you to move the Open Practice Library forward!

--- a/content/page/contributing.md
+++ b/content/page/contributing.md
@@ -5,7 +5,9 @@ authors:
   - springdo
 date: 2017-10-19T21:03:59.000Z
 menu: main
-weight: 0
+weight: 5
+aliases:
+  - /contributing/
 ---
 
 Welcome! Thank you for taking the time to contribute. This project relies on an active and involved community, and we really appreciate your support.

--- a/content/page/editorial.md
+++ b/content/page/editorial.md
@@ -3,8 +3,6 @@ title: Editorial Style
 authors:
   - rdebeasi
   - alexismonville
-menu: main
-weight: 0
 ---
 
 ## Tone

--- a/content/page/editorial.md
+++ b/content/page/editorial.md
@@ -35,7 +35,7 @@ A practice is an activity that helps teams achieve specific goals. It's not just
 
 A perspective is an idea that underpins a group of practices. It's a way of framing a problem. It's not something that you do; it's something that you have in mind as you do the practices.
 
-For example, [/perspective/domain-driven-design/](Domain Driven Design) is the perspective behind [Impact Mapping](/practice/impact-mapping/), [Event Storming](https://openpracticelibrary.com/practice/event-storming/), and [Start at the End](https://openpracticelibrary.com/practice/start-at-the-end/).
+For example, [Domain Driven Design](/perspective/domain-driven-design/) is the perspective behind [Impact Mapping](/practice/impact-mapping/), [Event Storming](https://openpracticelibrary.com/practice/event-storming/), and [Start at the End](https://openpracticelibrary.com/practice/start-at-the-end/).
 
 ## Gathering Feedback
 

--- a/content/page/editorial.md
+++ b/content/page/editorial.md
@@ -1,0 +1,48 @@
+---
+title: Editorial Style
+authors:
+  - rdebeasi
+  - alexismonville
+menu: main
+weight: 0
+---
+
+## Tone
+
+We're looking to be friendly and also authoritative, comprehensive and also concise. We use the active voice where possible to help guide teams to action. We don't always get it right, though. If you find something that could be clearer or punchier, feel free to send us a merge request!
+
+## What is a Practice?
+
+A practice is an activity that helps teams achieve specific goals. It's not just an idea; it's something that you _do_.
+
+### A practice _must_ be
+
+- **Empowering** - It helps teams discover and deliver iteratively.
+- **Concise** - It can be read in a few minutes.
+- **Agnostic** - It doesn't require the team to follow a specific project management framework.
+- **Proven** - It has been tested in the real world by the practice author.
+
+### A practice _should_ be
+
+- **Approachable** - It can be understood by someone who's not an expert in project management.
+- **Visual** - It includes images and videos.
+- **Accessible** - It includes alt text for images and captions for videos.
+- **Novel** - It isn't already covered by another practice.
+- **Deep** - It provides links to related resources, examples, and other materials for readers who want to explore further.
+- **Structured** - It consists of specific, discrete steps.
+- **Replicable** - It can be repeated across a variety of situations.
+- **Learned** - It is not innate knowledge  but rather habituated — and thus teachable!
+
+## What is a perspective?
+
+A perspective is an idea that underpins a group of practices. It's a way of framing a problem. It's not something that you do; it's something that you have in mind as you do the practices.
+
+For example, [/perspective/domain-driven-design/](Domain Driven Design) is the perspective behind [Impact Mapping](/practice/impact-mapping/), [Event Storming](https://openpracticelibrary.com/practice/event-storming/), and [Start at the End](https://openpracticelibrary.com/practice/start-at-the-end/).
+
+## Gathering Feedback
+
+As a community, we strive to provide kind and constructive feedback on your PR.
+
+If a pull request doesn't meet the "must be" guidelines, we may ask that the practice be updated before it's merged. If a pull request doesn't meet the "should be" guidelines, we may merge the pull request and add an issue for future improvements to the practice.
+
+Again, thank you so much for your interest and support! We look forward to enhancing the Open Practice Library.

--- a/content/page/home.md
+++ b/content/page/home.md
@@ -2,7 +2,7 @@
 title: Home
 menu: main
 url: /
-weight: 5
+weight: 6
 type: "home"
 ---
 

--- a/content/page/search.md
+++ b/content/page/search.md
@@ -4,4 +4,5 @@ date: 2017-10-19T17:03:59-04:00
 draft: false
 layout: search
 weight: 100
+url: /search/
 ---


### PR DESCRIPTION
**What issue does this PR solve?**

See below.

**Explain the problem and the proposed solution**

### Content Stuff

Contributing instructions were spread across the contributing page, the contributing markdown file, and the about page. I consolidated this info into the contributing page. The result was kind of long, so I broke it into "editorial" and "CMS" pages. `CONTRIBUTING.md` is now just a copy of the contributing page. Resolves #518.

The new "editorial" page has definitions for practices and perspectives. Resolves #519. Resolves #520.

I bumped "contributing" up so that it's listed along other internal links, and put perspectives right before it.

Finally, I removed the "just enough" paragraph from the About page, because we've started adding how-tos and other "more detailed content."

### Technical Stuff
We now have enough pages that I think it makes to group the URLs under `/pages/`, rather than dumping everything in the root. The site is now set up so that, for example, the About page lives at `/pages/about/` instead of `/about/`. There are redirects from the old URLs to the new ones.

I investigated nesting "editorial" and "CMS" inside "contributing", but Netlify CMS [doesn't yet support nesting](https://github.com/netlify/netlify-cms/issues/513).



Thoughts, @springdo @tdbeattie @mtakane ?