### PR TITLE
Add build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Practice Library
 
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/openpracticelibrary/) [Build Log](https://app.netlify.com/sites/openpracticelibrary/deploys?filter=master)
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/openpracticelibrary/) [![Netlify Status](https://api.netlify.com/api/v1/badges/2f44b7cd-f0eb-4f8b-9ade-51a338a7d1aa/deploy-status)](https://app.netlify.com/sites/openpracticelibrary/deploys)
 
 ## About
 


### PR DESCRIPTION
**What issue does this PR solve?**
We currently have a link to the build logs. This link doesn't clearly show whether our build is succeeding.

**Explain the problem and the proposed solution**
Add Netlify's new(ish) [deployment badge](https://www.netlify.com/blog/2019/01/29/sharing-the-love-with-netlify-deployment-badges/) to the readme. The link goes to a log of all builds, but the badge itself shows [only the status of production builds](https://www.netlify.com/docs/continuous-deployment/#status-badges).