### PR TITLE
Point to the new location for Netlify CMS JS

### DIFF
--- a/netlify-setup.md
+++ b/netlify-setup.md
@@ -24,7 +24,9 @@ This is a dump of some of the things we did to setup practice libaray on my gith
 
 #### Developing locally
 
-It's possible to run the admin locally, but it will exhibit some strange behavior (see [Netlify Issue 1085](https://github.com/netlify/netlify-cms/issues/1085)). For CMS development, consider forking the repo and setting up a new Netlify site that's connected to that fork.
+The simplest way to do this is to use the `test-repo-backend` documented at https://www.netlifycms.org/docs/authentication-backends/#test-repo-backend.
+
+The instructions below provide a way of running the admin locally and still pushing to a git repo, but following those instructions may introduce unexpected behavior (see [Netlify Issue 1085](https://github.com/netlify/netlify-cms/issues/1085)). For CMS development, consider forking the repo and setting up a new Netlify site that's connected to that fork.
 
 Currently, when the admin runs locally, it uses three different data sources:
 - `config.yml` comes from the local dev environment.

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
-  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
   <script src="https://unpkg.com/react@16/umd/react.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="previews.js" type="text/babel"></script>


### PR DESCRIPTION
**What issue does this PR solve?**

Resolves this console warning:
> You seem to be loading Netlify CMS by fetching `dist/cms.js` from a CDN. That file is deprecated and will be removed in the next major release. Please use `dist/netlify-cms.js` instead.

Resolves #559.

**Explain the problem and the proposed solution**
We were pointing to `dist/cms.js`. We are now pointing to `dist/netlify-cms.js`.