### PR TITLE
Fix blank "this practice is part of..." text

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -94,7 +94,7 @@
     </div>
     {{ end }}
 
-    {{ if (.Params.perspectives)  }}
+    {{ if .Params.perspectives }}
       {{ $numPerspectives := len .Params.perspectives }}
       <p><em>
         This {{ .Type }} is part of: 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -94,7 +94,7 @@
     </div>
     {{ end }}
 
-    {{ if isset .Params "perspectives"  }}
+    {{ if (.Params.perspectives)  }}
       {{ $numPerspectives := len .Params.perspectives }}
       <p><em>
         This {{ .Type }} is part of: 


### PR DESCRIPTION
**What issue does this PR solve?**

Resolves #689: Some practices without perspectives have blank "this practice is part of..." text.

**Explain the problem and the proposed solution**
Netlify CMS creates an empty array when the `perspectives` field is left empty. We were rendering the text on any practices where that field is set - even if the field is empty. This problem didn't affect old practices, but it did affect new ones.

Solution: check if the `perspectives` is truthy (nil or an empty array) instead of checking whether it's set.

Does this look ok, @springdo ?