### PR TITLE
Fix byline display and build problems

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,25 +46,26 @@
 <main class="content" role="main">
   <article class="post {{ .Section }}">
     <header class="post-header">
-
-      {{ $authorScratch := newScratch }}
-      {{ range $.Params.authors }}
-        {{ $currrentAuthor := index $.Site.Data.content.author .}}
-        {{ if $currrentAuthor }}
-          {{ $authorScratch.Add "listOfAuthors" (slice $currrentAuthor) }}
-        {{ else }}
-          {{/*Author isn't in site data. Build a simple author dictionary so that we can output the author's name.*/}}
-          {{ $authorScratch.Add "listOfAuthors" (slice (dict "title" . "github" .))}}
+      <section class="post-meta clearfix">
+        {{ $authorScratch := newScratch }}
+        {{ range $.Params.authors }}
+          {{ $currrentAuthor := index $.Site.Data.content.author .}}
+          {{ if $currrentAuthor }}
+            {{ $authorScratch.Add "listOfAuthors" (slice $currrentAuthor) }}
+          {{ else }}
+            {{/*Author isn't in site data. Build a simple author dictionary so that we can output the author's name.*/}}
+            {{ $authorScratch.Add "listOfAuthors" (slice (dict "title" . "github" .))}}
+          {{ end }}
         {{ end }}
-      {{ end }}
-      {{ $listOfAuthors := $authorScratch.Get "listOfAuthors"}}
-      {{ partial "author.html" $listOfAuthors }}
-
-      <section class="post-meta">
+        {{ $listOfAuthors := $authorScratch.Get "listOfAuthors"}}
+        {{ partial "author.html" $listOfAuthors }}
+    
+        <p class="post-date">
         Last update:
-        <time class="post-date" datetime="{{ .Page.Lastmod.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
-          {{ .Page.Lastmod.Format "January 2, 2006" }}
-        </time>
+          <time datetime="{{ .Page.Lastmod.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
+            {{ .Page.Lastmod.Format "January 2, 2006" }}
+          </time>
+        </p>
       </section>
 
       {{ partial "content-heading.html" .Params }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -50,7 +50,9 @@
       {{ $authorScratch := newScratch }}
       {{ range $.Params.authors }}
         {{ $currrentAuthor := index $.Site.Data.content.author .}}
-        {{ $authorScratch.Add "listOfAuthors" (slice $currrentAuthor) }}
+        {{ if $currrentAuthor }}
+          {{ $authorScratch.Add "listOfAuthors" (slice $currrentAuthor) }}
+        {{ end }}
       {{ end }}
       {{ $listOfAuthors := $authorScratch.Get "listOfAuthors"}}
       {{ partial "author.html" $listOfAuthors }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -52,6 +52,9 @@
         {{ $currrentAuthor := index $.Site.Data.content.author .}}
         {{ if $currrentAuthor }}
           {{ $authorScratch.Add "listOfAuthors" (slice $currrentAuthor) }}
+        {{ else }}
+          {{/*Author isn't in site data. Build a simple author dictionary so that we can output the author's name.*/}}
+          {{ $authorScratch.Add "listOfAuthors" (slice (dict "title" . "github" .))}}
         {{ end }}
       {{ end }}
       {{ $listOfAuthors := $authorScratch.Get "listOfAuthors"}}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -17,14 +17,15 @@
     </figure>
     {{end}}
     <div class="author-info">
-        <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
+      <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
+      {{ if gt (len $authors) 1 }}
         <p class="author-co-authors">
             Co-Authors:
             {{ range after 1 $authors }}
               {{ .title }}
             {{ end }}
         </p>
-
+      {{ end }}
     </div>
   </section>
   {{end}}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,36 +1,33 @@
 {{ if .}}
-{{$authors := .}}
-{{$coauthors := after 1 $authors }}
-{{$numcoauthors := len $coauthors}}
+  {{$authors := .}}
+  {{$coauthors := after 1 $authors }}
+  {{$numcoauthors := len $coauthors}}
 
-{{ range first 1 . }}
+  {{ range first 1 . }}
+    {{$authorname := .title}}
+    {{$authorbio := or .bio ""}}
+    {{$authorlocation := or .location ""}}
+    {{$authorgithubsite :=  print "https://github.com/" .github }}
+    {{$authorwebsite := or .website $authorgithubsite }}
+    {{$authoravatar :=  print "https://github.com/" .github ".png?size=140" }}
 
-  {{$authorname := .title}}
-  {{$authorbio := or .bio ""}}
-  {{$authorlocation := or .location ""}}
-  {{$authorgithubsite :=  print "https://github.com/" .github }}
-  {{$authorwebsite := or .website $authorgithubsite }}
-  {{$authoravatar :=  print "https://github.com/" .github ".png?size=140" }}
-
-
-  <section class="author">
-    {{with $authoravatar}}
-    <figure class="author-avatar">
-        <a class="img" href="{{$authorwebsite}}" style="background-image: url({{. | relURL}})"><span class="hidden">{{$authorname}}'s Picture</span></a>
-    </figure>
-    {{end}}
-    <div class="author-info">
-      <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
-      {{ if $coauthors }}
-        <p class="author-co-authors">
-          Co-Author{{ if gt $numcoauthors 1 }}s{{end}}:
-          {{ range $key, $coauthor := $coauthors }}
-            {{ $coauthor.title }}{{- if lt $key (sub $numcoauthors 1) }},{{ end }}
-          {{ end }}
-        </p>
-      {{ end }}
-    </div>
-  </section>
+    <section class="author">
+      {{with $authoravatar}}
+      <figure class="author-avatar">
+          <a class="img" href="{{$authorwebsite}}" style="background-image: url({{. | relURL}})"><span class="hidden">{{$authorname}}'s Picture</span></a>
+      </figure>
+      {{end}}
+      <div class="author-info">
+        <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
+        {{ if $coauthors }}
+          <p class="author-co-authors">
+            Co-Author{{ if gt $numcoauthors 1 }}s{{end}}:
+            {{ range $key, $coauthor := $coauthors }}
+              {{ $coauthor.title }}{{- if lt $key (sub $numcoauthors 1) }},{{ end }}
+            {{ end }}
+          </p>
+        {{ end }}
+      </div>
+    </section>
   {{end}}
-
 {{end}}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,6 +1,7 @@
 {{ if .}}
 {{$authors := .}}
 {{$coauthors := after 1 $authors }}
+{{$numcoauthors := len $coauthors}}
 
 {{ range first 1 . }}
 
@@ -22,9 +23,9 @@
       <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
       {{ if $coauthors }}
         <p class="author-co-authors">
-          Co-Authors:
+          Co-Author{{ if gt $numcoauthors 1 }}s{{end}}:
           {{ range $key, $coauthor := $coauthors }}
-            {{ $coauthor.title }}{{- if lt $key (sub (len $coauthors) 1) }},{{ end }}
+            {{ $coauthor.title }}{{- if lt $key (sub $numcoauthors 1) }},{{ end }}
           {{ end }}
         </p>
       {{ end }}

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,5 +1,7 @@
 {{ if .}}
 {{$authors := .}}
+{{$coauthors := after 1 $authors }}
+
 {{ range first 1 . }}
 
   {{$authorname := .title}}
@@ -18,12 +20,12 @@
     {{end}}
     <div class="author-info">
       <h4><a href="{{$authorwebsite}}">{{$authorname}}</a></h4>
-      {{ if gt (len $authors) 1 }}
+      {{ if $coauthors }}
         <p class="author-co-authors">
-            Co-Authors:
-            {{ range after 1 $authors }}
-              {{ .title }}
-            {{ end }}
+          Co-Authors:
+          {{ range $key, $coauthor := $coauthors }}
+            {{ $coauthor.title }}{{- if lt $key (sub (len $coauthors) 1) }},{{ end }}
+          {{ end }}
         </p>
       {{ end }}
     </div>


### PR DESCRIPTION
**What issue does this PR solve?**
If an author is listed in a practice but that author doesn't exist in `data/content/author`, the build will fail. This problem affects most new authors - someone has to add the new author in a separate PR before his or her contributions can go through.

Resolves #204.

Additionally, coauthors are not comma-delimited. The "co-authors" text will appear even if there is only a single author.

Resolves #523.

**Explain the problem and the proposed solution**
For each author that isn't in `data/content/author`, build a simple dictionary using the author's GitHub username as the title. That way, we can still show the author's name and pass the build.

Adding the username of a nonexistent GitHub user will cause the author's website link and author image to go to an error 404. That happens today if you add an invalid author to  `data/content/author`, and validating all GitHub usernames would slow down builds, so I'm ok leaving that behavior in place if there are no objections.

Comma-delimit authors, and only show the "co-authors" text if there's more than 1 author. If there's just one co-author, say "co-author" instead of "co-authors".

Thoughts, @springdo ?