### PR TITLE
Quick fix to get the icon of "start with why" to show succesfully

### DIFF
--- a/content/practice/start-with-why.md
+++ b/content/practice/start-with-why.md
@@ -6,7 +6,7 @@ authors:
   - tenfourty
 area: discovery-loop-why
 perspectives: []
-icon: /images/golden-circle.webp
+icon: /images/golden-circle.png
 jumbotron: /images/golden-circle.webp
 jumbotronAlt: Start With Why
 people: 1+


### PR DESCRIPTION
**What issue does this PR solve?**
Currently the live site is showing a dead image link for the start but why practice when it's displayed in a list.
**Explain the problem and the proposed solution**
Currently the live site is showing a dead image link for the start but why practice when it's displayed in a list. This is because it and the jumbotron are both pointing to an image that ends in webp which doesn't display for icons. This changes the icon image link to a png which will show.