### PR TITLE
Fixing image path reference issue when converting images in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,15 +59,15 @@ build(){
     mkdir -p $SCALED_PATH
     for original_file in $ORIGINAL_PATH*.{jpg,jpeg,png} ; do
     scaled_file="${original_file/$ORIGINAL_PATH/$SCALED_PATH}"
-    if [ -f $scaled_file ]; then
-        echo Exists: $scaled_file
+    if [ -f "$scaled_file" ]; then
+        echo Exists: "$scaled_file"
     else
         # 1. Scale each image to a minimum of 640x426, preserving aspect ratio.
         # 2. When cropping, align to the center.
         # 3. Crop image to exactly 640x426.
         # The \ isn't a geometry argument; it just escapes the > character.
-        echo Creating: $scaled_file
-        convert $original_file -resize 640x426^\> -gravity center -crop 640x426+0+0 $scaled_file
+        echo Creating: "$scaled_file"
+        convert "$original_file" -resize 640x426^\> -gravity center -crop 640x426+0+0 "$scaled_file"
     fi
     done
 


### PR DESCRIPTION
**What issue does this PR solve?**
This fixes #1020 

build script is generating warning messages when converting images whose filename contain spaces 

**Explain the problem and the proposed solution**

The problem was caused by path reference in variables in the build script. Quoting the variables in command lines solves the problems.
