### PR TITLE
hide menu ref links on mobile, remove like button for now

### DIFF
--- a/src/components/practicePage/PageMenu/SocialLinks.js
+++ b/src/components/practicePage/PageMenu/SocialLinks.js
@@ -61,12 +61,6 @@ export default function SocialLinks(props) {
     setLoc(window.location.href);
   }, []);
 
-  const handleLike = () => {
-    const originalLikes = props.upvotes;
-    const newUpvotes = originalLikes + 1;
-    return newUpvotes;
-  };
-
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const handleClick = (event) => {
@@ -83,14 +77,6 @@ export default function SocialLinks(props) {
   return (
     <>
       <Grid container direction="row" className={classes.root} spacing={1}>
-        <Grid item xs={3}>
-          <Typography className={classes.url} variant="overline">
-            Like
-          </Typography>
-          <IconButton onClick={handleLike} data-testid={"heartIcon"}>
-            <FavoriteBorder />
-          </IconButton>
-        </Grid>
         <Grid item>
           <Typography className={classes.url} variant="overline">
             Share{" "}

--- a/src/components/practicePage/PageMenu/index.js
+++ b/src/components/practicePage/PageMenu/index.js
@@ -8,6 +8,7 @@ import {
   Grid,
   Button,
   Typography,
+  Hidden,
 } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
@@ -56,29 +57,31 @@ export default function PageMenu(props) {
     <Toolbar component="nav" variant="dense" className={classes.root}>
       <Grid container direction="row" justify="center">
         <Grid item xs={false} md={1} xl={2}></Grid>
-        <Grid item xs={8} md={6} xl={5}>
-          <Container maxWidth="md">
-            <Grid
-              container
-              direction="row"
-              justify="space-between"
-              alignItems="flex-start"
-              spacing={1}
-            >
-              {sections.map((section, i) => (
-                <Grid item key={i}>
-                  <Button
-                    onClick={() => handleClick(section.ref)}
-                    className={classes.pageNavButton}
-                  >
-                    <Typography variant="overline">{section.title}</Typography>
-                  </Button>
-                </Grid>
-              ))}
-            </Grid>
-          </Container>
-        </Grid>
-        <Grid item xs={4}>
+        <Hidden only="xs">
+          <Grid item md={6} xl={5}>
+            <Container maxWidth="md">
+              <Grid
+                container
+                direction="row"
+                justify="space-between"
+                alignItems="flex-start"
+                spacing={1}
+              >
+                {sections.map((section, i) => (
+                  <Grid item key={i}>
+                    <Button
+                      onClick={() => handleClick(section.ref)}
+                      className={classes.pageNavButton}
+                    >
+                      <Typography variant="overline">{section.title}</Typography>
+                    </Button>
+                  </Grid>
+                ))}
+              </Grid>
+            </Container>
+          </Grid>
+        </Hidden>
+        <Grid item xs={12} md={4}>
           <SocialLinks
             practiceId={props.practiceId}
             upvotes={props.upvotes}

--- a/src/components/practicePage/index.js
+++ b/src/components/practicePage/index.js
@@ -88,6 +88,7 @@ const PracticePage = ({ data }) => {
         borderBottom="1px solid rgba(0, 0, 0, 0.12)"
         zIndex={1001}
         py={1}
+        bgcolor="white"
       >
         <PageMenu {...pageMenuData} {...pageRefs} />
       </Box>


### PR DESCRIPTION
**What issue does this PR solve?**
Makes the practice page more responsive

**Explain the problem and the proposed solution**
- Practice Page menu bar looks awful on mobile
- Hide the page ref links on mobile screens
- Removed `Like` button for now, can restore easily if we want it to work in `next` version.