### PR TITLE
fixed tags and format for 3 practices

### DIFF
--- a/src/pages/practice/parking-lot-car-park.md
+++ b/src/pages/practice/parking-lot-car-park.md
@@ -8,12 +8,48 @@ date: 2020-07-21T14:52:33.202Z
 authors:
   - mtakane
 area: foundation-culture-and-collaboration
+tags:
+  - foundation
+  - culture
 perspectives: []
 people: 2+
 time: varies
 difficulty: easy
 participants:
   - everybody
+whatIs: >-
+  A visible location in a room or virtual whiteboard that looks to capture any type of topic that is not important to discuss at the time, but deemed worthy to discuss later by the group gathered. Is a means to capture the thought and intention so that it is heard and understood, and then placed somewhere so that it is not forgotten and followed up on at a later time.
+whyDo: >-
+  Many groups of people getting together tend to go off-topic or the purpose of the discussion is in danger of being derailed. Whether the discussion is a single meeting or part of a longer workshop or series of conversations. To ensure the intent of the discussion is met, a Parking Lot is a way to capture the "off" topic/idea and then continue on. By doing so, you are more likely to achieve the main purpose of the discussion and have followup items to think on and discuss during any remaining time or in subsequent discussions. You have also looked to ensure that each individual in the group is heard, understood, and not forgotten in their contributions. When used to foster open communication and not where ideas are ceremonially dismissed, you will see increased inclusivity and open collaboration for the main topic, while also generating important insights to discuss later.
+howTo: >-
+  1. Agree on a visible location to capture topics to discuss later
+
+     * Physically Present: Use a space on a wall and post its to capture the topics.
+     * Remotely Present: Use a shared document everybody can see/access onscreen during the discussion.
+  2. Agree as a group how to go about identifying and capturing the off-topic items
+
+     * Anybody at anytime may identify a topic as being off-topic and should be captured. This sparks a majority rules discussion on if it is off-topic or should be resolved immediately.
+     * You add your own idea to the Parking Lot (or rotate who is the scribe).
+  3. Allot some time at the end of the timebox to review Parking Lot items to determine what the appropriate next steps are for them.
+
+     * 5-10 minutes is a good starting place, but depends on the amount of items captured.
+
+  ### Facilitation Tips
+
+  * If possible, have the Parking Lot in a place that is frequently visited by the people gathered (virtually or physically)
+
+  * Recommend identifying a key person to either own each Parking Lot item or can speak on behalf of the item's intent
+
+  * Do not designate a single person to capture all the Parking Lot items.
+
+  * During the meeting have your eye on the Parking Lot items to see if any are resolved naturally through the remainder of the timebox and call it out when it happens.
+resources:
+  - link: https://thinklouder.com/quicktip-open-meeting-parking-lot/
+    linkType: web
+    description: Interesting take on tagging items as a followup discussion and to account for that time 'outside' the existing meeting
+  - link: http://www.agile-ux.com/2010/12/16/parking-lot-a-good-facilitation-tool/
+    linkType: web
+    description: Addresses some of how to account for time to discuss the items in the Parking Lot
 ---
 ## What is it?
 

--- a/src/pages/practice/relative-estimation.md
+++ b/src/pages/practice/relative-estimation.md
@@ -23,6 +23,7 @@ authors:
   - mvmaestri
 area: foundation-culture-and-collaboration
 tags:
+  - foundation
   - methods
 icon: /images/final_relative-sizing.png
 people: 2+

--- a/src/pages/practice/risk-issue-management.md
+++ b/src/pages/practice/risk-issue-management.md
@@ -9,12 +9,47 @@ date: 2018-08-28T08:32:36.565Z
 authors:
   - sandraarps
 area: foundation-culture-and-collaboration
+tags:
+  - foundation
+  - culture
 icon: /images/img_1606.jpg
 people: 2+
 time: 60 min
 difficulty: easy
 participants:
   - Iteration Manager + Product Owner + Team
+whatIs: To help the team identifying and evaluating risks (potential issues) and finding actions to avoid or minimise their impact on time, cost and or scope.
+whyDo: It will reduce the likelihood of the event to happen and reduce the magnitude of its impact
+howTo: >-
+  * The best approach to identifying risks is to arrange a workshop where the participants will brainstorm on potential, future risks
+
+  * First, risks needs to be identified which can have an impact to the project or outcome
+
+  * Some example of risks are:
+    * Inadequate delivery capability (due to team experience, lack of inconsistent methodology or process)
+    * Ineffective delivery (due to unclear roles & responsibilities, issues not being escalated)
+    * Inadequate management of stakeholders (due to expectations not being identified)
+    * Unclear project or activity value (due to poor evaluation of business ownership of benefits)
+    * Resource limitations (due to skill shortages)
+    * Failure to recognise & manage dependencies (due to lack of communication)
+    * Failure of external vendors / suppliers (due to poor engagement)
+  * Next, the risks need to be rated based on likelihood and impact at the present time
+
+  * Once the risks have been rated, mitigation strategies need to identified.
+
+  * Last but not least, the risks will be displayed in the team area, where the Daily Standup's happen. That way, the risks can be reviewed on a daily basis and dealt with, if / once they occur.
+mediaGallery:
+  - link: https://d33wubrfki0l68.cloudfront.net/1f63ec8dbee313481682310211f24ba74ac91c08/c7c83/images/scaled/img_1606.jpg
+resources:
+  - link: https://www.agilealliance.org/wp-content/uploads/2016/01/Agile-Risk-Management-Agile-2012.pdf
+    linkType: web
+    description: Agile Risk Management presentation from Greg Smith
+  - link: https://www.todaysoftmag.com/article/1367/a-simple-approach-for-risk-management-in-scrum
+    linkType: web
+    description: A Simple Approach for Risk Management in Scrum by Sebastian Botis
+  - link: http://www.disciplinedagiledelivery.com/agile-risk-management/
+    linkType: web
+    description: The Disciplined Agile (DA) Framework - Agile Risk Management
 ---
 ## What is it?
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -103,6 +103,34 @@ collections:
           - label: "Description"
             name: "description"
             widget: "string"
+      - label: "No. of people required"
+        hint: "How many people are needed for the practice eg 2+ or 10"
+        name: "people"
+        widget: "string"
+        required: false
+      - label: "Time length"
+        hint: "How long is needed to facilitate this practice"
+        name: "time"
+        widget: "string"
+        required: false
+      - label: "Facilitation difficulty"
+        hint: "How difficult is it to facilitate this practice"
+        name: "difficulty"
+        widget: "select"
+        required: false
+        options:
+          - label: "Easy"
+            value: "easy"
+          - label: "Moderate"
+            value: "moderate"
+          - label: "Hard"
+            value: "hard"
+      - label: "Expected participants"
+        hint: "Who should attend when running this practice? eg., The Team, The Product Owner, BAs"
+        name: "participants"
+        required: false
+        widget: "list"
+        default: []
   - name: "perspective" # Used in routes, e.g., /admin/collections/blog
     label: "Perspective" # Used in the UI
     publish: false


### PR DESCRIPTION
**What issue does this PR solve?**
- Risk Issue Management
- Parking Lot
- Relative Estimation

Also, added the Facilitation Details section back to the netlify cms schema, so they can be edited or added to new practices. These still aren't displayed in `next` and aren't part of the v3 schema, but we can keep it around in case we're asked to put it back.