### PR TITLE
:bug: Fixed What Is title typo (Issue #1288)

### DIFF
--- a/src/components/practicePage/PageBody/index.js
+++ b/src/components/practicePage/PageBody/index.js
@@ -25,7 +25,7 @@ const PageBody = ({
         {whatIs && (
           <>
             <Typography gutterBottom variant="h4" ref={whatIsRef}>
-              WhatIs {title}?
+              What Is {title}?
             </Typography>
             <FullText source={whatIs} />
           </>


### PR DESCRIPTION
**What issue does this PR solve?**

This PR resolve the issue [#1288](https://github.com/openpracticelibrary/openpracticelibrary/issues/1288), a typo in the What Is title in practice page template

**Explain the problem and the proposed solution**

Added a space in What Is tittle in the Practice Page template.
