### PR TITLE
Fix add links we love

### DIFF
--- a/src/components/practicePage/PageBody/MediaGallery.js
+++ b/src/components/practicePage/PageBody/MediaGallery.js
@@ -11,9 +11,14 @@ export default function MediaGallery({
   mediaRef,
 }) {
   const images = mediaGallery.map((media) => {
-    const url = media.link
-      ? new URL(media.link)
-      : new URL("https://via.placeholder.com/300");
+
+    var url;
+    try {
+        url = media.link ? new URL(media.link) : new URL("https://via.placeholder.com/300");
+    } catch (TypeError) {
+        url = new URL("https://via.placeholder.com/300");
+    }
+
     if (url.hostname.includes("youtube") && url.pathname.includes("watch")) {
       const youtubeId = url.searchParams.get("v");
       const link = `https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`;

--- a/src/components/practicePage/PageBody/ResourceListItem.js
+++ b/src/components/practicePage/PageBody/ResourceListItem.js
@@ -4,13 +4,19 @@ import { Link } from "gatsby";
 import { Typography, Box } from "@material-ui/core";
 
 const ResourceListItem = ({ children, description, listItemKey, url }) => {
-  const linkValue = new URL(url);
+  var linkValue;
+  var validUrl = true;
+  try {
+    linkValue = new URL(url);
+  } catch (TypeError) {
+    validUrl = false;
+  }
   return (
     <>
       <Box display="flex">
         <Box>{children}</Box>
         <Box>
-          {linkValue.hostname === "openpracticelibrary.com" ? (
+          {validUrl && linkValue.hostname === "openpracticelibrary.com" ? (
             <Link to={linkValue.pathname}>
               <Typography variant="body1" key={listItemKey}>
                 {description}

--- a/src/components/practicePage/PageBody/Resources.js
+++ b/src/components/practicePage/PageBody/Resources.js
@@ -24,7 +24,7 @@ export default function ResourcesWeLove(props) {
   const resourceLinkList = () => {
     if (Object.keys(props.links[0]).length !== 0) {
       const resourceList = props.links.filter(
-        (resource) => (resource.link.length != null) ? (resource.link.length > 0) : false
+        (resource) => (resource.link != null) ? (resource.link.length > 0) : false
       );
       const listLength = resourceList.length;
       let initialLinkList = [];

--- a/src/components/practicePage/PageBody/Resources.js
+++ b/src/components/practicePage/PageBody/Resources.js
@@ -24,7 +24,7 @@ export default function ResourcesWeLove(props) {
   const resourceLinkList = () => {
     if (Object.keys(props.links[0]).length !== 0) {
       const resourceList = props.links.filter(
-        (resource) => resource.link.length > 0
+        (resource) => (resource.link.length != null) ? (resource.link.length > 0) : false
       );
       const listLength = resourceList.length;
       let initialLinkList = [];


### PR DESCRIPTION
Fixes #1334 

It also fixes an unreported bug with the exception handling the the links url field for "Links we love" and "Media Gallery" links.

A user cannot type in the link url as it expects the url to be copied and pasted only.