### PR TITLE
Use Anchor.fm podcast links

### DIFF
--- a/src/components/shared/BodyFooter/index.js
+++ b/src/components/shared/BodyFooter/index.js
@@ -48,7 +48,7 @@ const BodyFooter = () => {
             <Grid container spacing={2}>
               <Grid item>
                 <Link
-                  href="https://podcasts.apple.com/us/podcast/open-practice-podcast/id1501715186"
+                  href="https://anchor.fm/openpracticelibrary"
                   rel="noreferrer"
                   target="_blank"
                 >

--- a/src/components/shared/Drawer/DrawerFooter.js
+++ b/src/components/shared/Drawer/DrawerFooter.js
@@ -14,7 +14,7 @@ const DrawerFooter = () => (
       <ListItem
         button
         component="a"
-        href="https://podcasts.apple.com/us/podcast/open-practice-podcast/id1501715186"
+        href="https://anchor.fm/openpracticelibrary"
         target="_blank"
         rel="noreferrer"
       >

--- a/src/pages/practice/candy-or-swag.md
+++ b/src/pages/practice/candy-or-swag.md
@@ -107,7 +107,7 @@ howTo: >-
 mediaGallery:
   - link: https://openpracticelibrary.github.io/opl-media/images/candy-or-swag.png
 resources:
-  - link: https://podcasts.apple.com/us/podcast/retrospectives-w-mary-provinciatto/id1501715186?i=1000486726700
+  - link: https://anchor.fm/openpracticelibrary/episodes/Retrospectives-w-Mary-Provinciatto-eh6acr
     linkType: podcast
     description: Retrospectives Open Practice Podcast Episode
   - link: https://opensource.com/open-organization/resources/open-org-definition

--- a/src/pages/practice/continuous-delivery.md
+++ b/src/pages/practice/continuous-delivery.md
@@ -31,7 +31,7 @@ howTo: This practice typically requires automation that is run on a server such
 mediaGallery:
   - link: https://github.com/openpracticelibrary/opl-media/blob/master/images/continuous%20delivery.png?raw=true
 resources:
-  - link: https://podcasts.apple.com/us/podcast/ci-cd-w-tyler-auerbeck/id1501715186?i=1000491737000
+  - link: https://anchor.fm/openpracticelibrary/episodes/CICD-w-Tyler-Auerbeck-ejr13l
     linkType: podcast
     description: CI/CD Open Practice Podcast Episode
   - link: https://jenkins.io/

--- a/src/pages/practice/continuous-deployment.md
+++ b/src/pages/practice/continuous-deployment.md
@@ -42,7 +42,7 @@ howTo: >-
 mediaGallery:
   - link: https://github.com/openpracticelibrary/opl-media/blob/master/images/continuous%20deployment.png?raw=true
 resources:
-  - link: https://podcasts.apple.com/us/podcast/ci-cd-w-tyler-auerbeck/id1501715186?i=1000491737000
+  - link: https://anchor.fm/openpracticelibrary/episodes/CICD-w-Tyler-Auerbeck-ejr13l
     linkType: podcast
     description: CI/CD Open Practice Podcast Episode
   - link: https://openpracticelibrary.com/practice/continuous-integration/

--- a/src/pages/practice/continuous-integration.md
+++ b/src/pages/practice/continuous-integration.md
@@ -13,7 +13,7 @@ howTo: The tests and build steps are typically run in an automation server such
   are also cloud native/kubernetes solutions such as
   [Tekton](https://tekton.dev/).
 resources:
-  - link: https://podcasts.apple.com/us/podcast/ci-cd-w-tyler-auerbeck/id1501715186?i=1000491737000
+  - link: https://anchor.fm/openpracticelibrary/episodes/CICD-w-Tyler-Auerbeck-ejr13l
     linkType: podcast
     description: CI/CD Open Practice Podcast Episode
   - link: https://jenkins.io/

--- a/src/pages/practice/decision-jam.md
+++ b/src/pages/practice/decision-jam.md
@@ -74,7 +74,7 @@ resources:
   - link: https://www.interaction-design.org/literature/article/what-is-design-thinking-and-why-is-it-so-popular
     linkType: web
     description: Design Thinking
-  - link: https://podcasts.apple.com/us/podcast/lightning-decision-jam-w-jonathan-courtney/id1501715186?i=1000476221425
+  - link: https://anchor.fm/openpracticelibrary/episodes/Lightning-Decision-Jam-w-Jonathan-Courtney-ee9dqi
     linkType: podcast
     description: LDJ Open Practice Podcast Episode
   - link: https://openpracticelibrary.com/practice/design-sprint/

--- a/src/pages/practice/lean-coffee.md
+++ b/src/pages/practice/lean-coffee.md
@@ -62,7 +62,7 @@ resources:
     linkType: web
     description: Lean Coffee Facilitator's Guide
   - linkType: podcast
-    link: https://podcasts.apple.com/us/podcast/lean-coffee-w-prakriti-koller/id1501715186?i=1000533128785
+    link: https://anchor.fm/openpracticelibrary/episodes/Lean-Coffee-w-Prakriti-Koller-e166qv9
     description: Lean Coffee episode on Open Practice Podcast
 difficulty: easy
 participants:

--- a/src/pages/practice/realtime-retrospective.md
+++ b/src/pages/practice/realtime-retrospective.md
@@ -133,7 +133,7 @@ resources:
   - link: http://emilywebber.co.uk/the-realtime-retrospective/
     linkType: web
     description: Realtime Retrospectives
-  - link: https://podcasts.apple.com/us/podcast/retrospectives-w-mary-provinciatto/id1501715186?i=1000486726700
+  - link: https://anchor.fm/openpracticelibrary/episodes/Retrospectives-w-Mary-Provinciatto-eh6acr
     linkType: podcast
     description: Retrospectives Open Practice Podcast Episode
   - link: https://www.amazon.com/Post-Sticky-Janeiro-Collection-6845-SSP/dp/B000CD0MHQ/

--- a/src/pages/practice/retrospectives.md
+++ b/src/pages/practice/retrospectives.md
@@ -127,7 +127,7 @@ howTo: >-
 mediaGallery:
   - link: https://openpracticelibrary.github.io/opl-media/images/pirate-retro.png
 resources:
-  - link: https://podcasts.apple.com/us/podcast/retrospectives-w-mary-provinciatto/id1501715186?i=1000486726700
+  - link: https://anchor.fm/openpracticelibrary/episodes/Retrospectives-w-Mary-Provinciatto-eh6acr
     linkType: podcast
     description: Retrospectives Open Practice Podcast Episode
   - link: http://amzn.eu/is9H7Az

--- a/src/pages/practice/t2r2-talk-type-read-review.md
+++ b/src/pages/practice/t2r2-talk-type-read-review.md
@@ -39,7 +39,7 @@ howTo: >-
 mediaGallery:
   - link: https://openpracticelibrary.github.io/opl-media/images/t2r2.jpg
 resources:
-  - link: https://podcasts.apple.com/us/podcast/t2r2-w-donna-benjamin/id1501715186?i=1000482347700
+  - link: https://anchor.fm/openpracticelibrary/episodes/T2R2-w-Donna-Benjamin-eg6ah7
     linkType: podcast
     description: Listen to the Open Practice Podcast episode about T2R2!
   - link: https://en.wikipedia.org/wiki/Zing_Technologies

--- a/src/pages/practice/the-big-picture.md
+++ b/src/pages/practice/the-big-picture.md
@@ -49,7 +49,7 @@ mediaGallery:
   - link: https://www.youtube.com/watch?v=qXb1naW0zdY
   - link: https://github.com/openpracticelibrary/opl-media/blob/master/big-pic.png?raw=true
 resources:
-  - link: https://podcasts.apple.com/us/podcast/the-big-picture-w-haitham-shahin/id1501715186?i=1000488772813
+  - link: https://anchor.fm/openpracticelibrary/episodes/The-Big-Picture-w-Haitham-Shahin-ehg7d6
     linkType: podcast
     description: Big Picture Open Practice Podcast Episode
 participants:


### PR DESCRIPTION
**What issue does this PR solve?**

Site podcast links are all to Apple Podcasts, which is not particularly usable for non-Apple users who just want an RSS feed.

See #1730 

**Explain the problem and the proposed solution**

Change the links to Anchor.fm instead, which is where Apple Podcasts gets the feed from anyway, and which gives links to Apple Podcasts, several other podcast services, and a plain RSS feed.