### PR TITLE
fix: Allow empty resource lists

### DIFF
--- a/src/components/practicePage/PageBody/Resources.js
+++ b/src/components/practicePage/PageBody/Resources.js
@@ -22,7 +22,7 @@ const Icon = {
 export default function ResourcesWeLove(props) {
   const [expanded, setExpanded] = React.useState(false);
   const resourceLinkList = () => {
-    if (Object.keys(props.links[0]).length !== 0) {
+    if (props.links.length !== 0 && Object.keys(props.links[0]).length !== 0) {
       const resourceList = props.links.filter(
         (resource) => (resource.link != null) ? (resource.link.length > 0) : false
       );


### PR DESCRIPTION
**What issue does this PR solve?**
Fixes #1753

**Explain the problem and the proposed solution**
The issue was due to an out-of-index access error from accessing the first element of an empty array, when attempting to render a practice page.

The fix was to simply add a check, to make sure the array wasn't empty before attempting to access the first value in the array.