### PR TITLE
Amend author hint

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -37,7 +37,7 @@ collections:
         name: "date"
         widget: "datetime"
       - label: "Authors"
-        hint: "Comma-separated list of LOWER CASE github usernames eg., springdo, rdebeasi, tdbeattie"
+        hint: "Comma-separated list of case-sensitive github usernames eg., Springdo, rdebeasi, TdBeattie"
         name: "authors"
         widget: "list"
         default: []


### PR DESCRIPTION
Summary
Updated hint to ensure author is displayed on practices. 

Explanation 
GitHub usernames listed in Netily must exactly match GitHub. If they do not match, the author will not appear on the practice. For example, if I list rohandr, but in GitHub my username is RohanDr, the practice will not display me as an author. The hint has been updated to reflect this new advice. 

Addresses 
https://github.com/openpracticelibrary/openpracticelibrary/issues/1833