### PR TITLE
Adds 🔗 link 🔗  to netlify in the footer

### DIFF
--- a/src/components/shared/BodyFooter/index.js
+++ b/src/components/shared/BodyFooter/index.js
@@ -121,7 +121,8 @@ const BodyFooter = () => {
               <CCHeart />
               Creative Commons Attribution 4.0
             </Link>{" "}
-            International license.
+            International license.<br />
+              <a href="https://www.netlify.com/open-source/">Hosted on Netlify</>
           </Typography>
         </Box>
       </Container>


### PR DESCRIPTION
In order to qualify for an opensource license, we need to link to netlify