### PR TITLE
2nd attempt to add netlify link

### DIFF
--- a/src/components/shared/BodyFooter/index.js
+++ b/src/components/shared/BodyFooter/index.js
@@ -122,7 +122,14 @@ const BodyFooter = () => {
               Creative Commons Attribution 4.0
             </Link>{" "}
             International license.<br />
-              <a href="https://www.netlify.com/open-source/">Hosted on Netlify</a>
+              Hosted on{" "}
+            <Link
+              href="https://www.netlify.com/open-source/" 
+              target="_blank"
+              rel="noopener"
+            >
+              Netlify
+              </Link>{" "}
           </Typography>
         </Box>
       </Container>


### PR DESCRIPTION
2nd try at adding link to netlify to the footer so that we can apply for opensource licence.

First attempt failed because I didn't use JS syntax.