### PR TITLE
Update send-google-chat-webhook GitHub Action version

### DIFF
--- a/.github/workflows/end-to-end-testing.yaml
+++ b/.github/workflows/end-to-end-testing.yaml
@@ -33,7 +33,7 @@ jobs:
           # this is automatically set by GitHub
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: notify google chat
-        uses: google-github-actions/send-google-chat-webhook@v0.0.1
+        uses: google-github-actions/send-google-chat-webhook@26a9cf348a936abbb72216d289b1241b5105ad28
         with:
           webhook_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
           mention: <users/all>


### PR DESCRIPTION
**What issue does this PR solve?**
No issue created

**Explain the problem and the proposed solution**
Fixes GitHub Action version, which was released without the `action.yml` file