### PR TITLE
Deletegchatnote

### DIFF
--- a/.github/workflows/end-to-end-testing.yaml
+++ b/.github/workflows/end-to-end-testing.yaml
@@ -32,8 +32,3 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # this is automatically set by GitHub
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: notify google chat
-        uses: google-github-actions/send-google-chat-webhook@26a9cf348a936abbb72216d289b1241b5105ad28
-        with:
-          webhook_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
-          mention: <users/all>


### PR DESCRIPTION
**What issue does this PR solve?**

After deleting the gchat notification on gchat, the tests here in github were borked, cos of course the webhook didn't work anymore.

**Explain the problem and the proposed solution**

Deleted the gchat notification from the test workflow