### PR TITLE
:bento: Add Open Collective and Redbubble links

### DIFF
--- a/src/components/shared/BodyFooter/index.js
+++ b/src/components/shared/BodyFooter/index.js
@@ -14,6 +14,8 @@ import {
   Instagram,
   Twitter,
   LinkedIn,
+  Sell,
+  AccountBalanceWallet
 } from "@mui/icons-material";
 import { CCHeart } from "../../../assets/icons/index";
 import Logo from "../../../components/shared/Logo";
@@ -101,6 +103,24 @@ const BodyFooter = () => {
                   <LinkedIn />
                 </Link>
               </Grid>
+              <Grid item>
+                <Link
+                  href="https://www.redbubble.com/shop/ap/153791137"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <Sell />
+                </Link>
+              </Grid>
+              <Grid item>
+                <Link
+                  href="https://opencollective.com/openpracticelibrary"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <AccountBalanceWallet />
+                </Link>
+              </Grid>
             </Grid>
           </Box>
         </Box>
@@ -122,7 +142,7 @@ const BodyFooter = () => {
             </Link>{" "}
             International license. This site is graciously hosted by{" "}
             <Link
-              href="https://www.netlify.com/open-source/" 
+              href="https://www.netlify.com/open-source/"
               target="_blank"
               rel="noopener"
             >


### PR DESCRIPTION
Extend community links with Open Collectiva and RedBubble.

**What issue does this PR solve?**

This PR fixes the #2223 issue adding into the community links both references.

![image](https://github.com/openpracticelibrary/openpracticelibrary/assets/8723668/29979bb9-0a67-4660-9603-e971736cdba3)

Sell Icon - https://mui.com/material-ui/material-icons/?query=sell&selected=Sell linking to RedBubble
AccountBalanceWallet Icon - https://mui.com/material-ui/material-icons/?query=AccountBalanceWallet&selected=AccountBalanceWallet linking to Open Collective

**Explain the problem and the proposed solution**

[Mui Core](https://mui.com/material-ui/material-icons/) does not include official icons for both references, so I chose similar ones to represent the main goal of each site (selling, funding). With this approach we don't need to create new assets for them, until someday they could be part of that library. If the community thinks that other icons could fit better here, please, let me know.