### PR TITLE
:busts_in_silhouette: Update contact information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ Welcome! Thank you for taking the time to contribute. This project relies on an 
 
 ## Code of Conduct
 
-This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be reported by contacting the project team at
-[rhc-open-innovation-labs@redhat.com](mailto:rhc-open-innovation-labs@redhat.com).
+This project is governed by our [Code of Conduct](CODE_OF_CONDUCT.md). All participants are expected to uphold this code. Violations of the code can be
+reported by contacting the community team at [info@openpracticelibrary.com](mailto:info@openpracticelibrary.com).
 
 ## How to contribute
 


### PR DESCRIPTION
**What issue does this PR solve?**

The current Contribution Guide refers to a project team that it is no longer behind of this community. Referening to the Community team under the contact email could help better to spread it and open the collaboration.

**Explain the problem and the proposed solution**

Align the content of the OPL to a better community, not just built by Red Hat.