### PR TITLE
Update README.md to remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Open Practice Library
-[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/openpracticelibrary/) [![Netlify Status](https://api.netlify.com/api/v1/badges/2f44b7cd-f0eb-4f8b-9ade-51a338a7d1aa/deploy-status)](https://app.netlify.com/sites/openpracticelibrary/deploys)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/2f44b7cd-f0eb-4f8b-9ade-51a338a7d1aa/deploy-status)](https://app.netlify.com/sites/openpracticelibrary/deploys)
 
 ## About
 


### PR DESCRIPTION
**What issue does this PR solve?**
#2263 

**Explain the problem and the proposed solution**
We used to use Gitter for real-time chat, but have not done so for a long time, and now Gitter no longer even exists.  We need to remove remaining references to Gitter from OPL.  A big 🙏 Thank you to @Moosh-be 🙏  for raising issue #2263 