### PR TITLE
Adding mobious loop name to practice header

### DIFF
--- a/src/components/practicePage/PageIntro/index.js
+++ b/src/components/practicePage/PageIntro/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ContributedBy from "./ContributedBy";
 import Collection from "../../shared/Collection";
 import { Box, Container, Typography } from "@mui/material";
+import mobiusContent from "../../../utilities/mobuisContent";
 
 const PageIntro = ({
   title,
@@ -16,6 +17,7 @@ const PageIntro = ({
   questions,
   date,
   preview,
+  mobiusTag,
 }) => (
   <Container maxWidth="md">
     <Box display="flex" flexDirection="column" marginTop={3}>
@@ -24,6 +26,13 @@ const PageIntro = ({
       </Typography>
       <Typography variant="h5" data-testid={"subtitle"}>
         {subtitle}
+      </Typography>
+    </Box>
+    <Box display="flex" flexDirection="row" justifyContent="flex-start" alignItems="center" pr={3} minWidth="fit-content">
+    <Typography variant="overline">A practice of</Typography>
+      {mobiusContent[mobiusTag.toLowerCase()].icon}
+      <Typography variant="h7" data-testid={"mobiusTag"}>
+        { "options" === mobiusTag ? "DECIDE" : mobiusTag.toUpperCase()}
       </Typography>
     </Box>
     <ContributedBy

--- a/src/components/practicePage/index.js
+++ b/src/components/practicePage/index.js
@@ -63,6 +63,7 @@ const PracticePage = ({ data, preview }) => {
     date,
     imgCount: mediaGallery ? mediaGallery.length : 0,
     preview,
+    mobiusTag,
   };
 
   const pageMenuData = { practiceId };


### PR DESCRIPTION
**What issue does this PR solve?**

This PR should resolve the #1466 issue adding the name of the mobius loop where the practice is located as part of the header.

**Explain the problem and the proposed solution**

Each practice is located into a specific area of the Mobius loop, however, that information is not available in the practice page, just only the header displays the same color of the loop without other references. This is an initial implementation of how to present the content of that information in the header.

The layout of the practice will be similar to:

Foundation:
![image](https://github.com/user-attachments/assets/9eb0f83f-0cb6-49c0-bca0-63666508c9f1)

Discovery:
![image](https://github.com/user-attachments/assets/506fd389-7023-42af-9c6c-ce79d47f727b)

Decide:
![image](https://github.com/user-attachments/assets/a1fcb533-8602-4311-9ce8-306c6310594f)

Delivery:
![image](https://github.com/user-attachments/assets/01ef0050-f87d-4a83-afd3-e1ef3db80b61)

The implementation is open to suggestions about how and where to present that information. 