### PR TITLE
Link practices to mobius #2371

### DIFF
--- a/src/components/practicePage/PageIntro/index.js
+++ b/src/components/practicePage/PageIntro/index.js
@@ -29,11 +29,14 @@ const PageIntro = ({
       </Typography>
     </Box>
     <Box display="flex" flexDirection="row" justifyContent="flex-start" alignItems="center" pr={3} minWidth="fit-content">
-    <Typography variant="overline">A practice of</Typography>
-      {mobiusContent[mobiusTag.toLowerCase()].icon}
-      <Typography variant="h7" data-testid={"mobiusTag"}>
+      <a href="/tags/{mobiusTag}">
+        {mobiusContent[mobiusTag.toLowerCase()].icon}
+      </a>
+      <a href="/tags/{mobiusTag}">
+        <Typography variant="h7" data-testid={"mobiusTag"}>
         { "options" === mobiusTag ? "DECIDE" : mobiusTag.toUpperCase()}
-      </Typography>
+        </Typography>
+      </a>
     </Box>
     <ContributedBy
       authors={authors}

--- a/src/components/practicePage/PageIntro/index.js
+++ b/src/components/practicePage/PageIntro/index.js
@@ -29,10 +29,10 @@ const PageIntro = ({
       </Typography>
     </Box>
     <Box display="flex" flexDirection="row" justifyContent="flex-start" alignItems="center" pr={3} minWidth="fit-content">
-      <a href="/tags/{"mobiusTag"}">
+      <a href="/tags/{mobiusTag}">
         {mobiusContent[mobiusTag.toLowerCase()].icon}
       </a>
-      <a href="/tags/{"mobiusTag"}">
+      <a href="/tags/{mobiusTag}">
         <Typography variant="h7" data-testid={"mobiusTag"}>
         { "options" === mobiusTag ? "DECIDE" : mobiusTag.toUpperCase()}
         </Typography>

--- a/src/components/practicePage/PageIntro/index.js
+++ b/src/components/practicePage/PageIntro/index.js
@@ -29,10 +29,10 @@ const PageIntro = ({
       </Typography>
     </Box>
     <Box display="flex" flexDirection="row" justifyContent="flex-start" alignItems="center" pr={3} minWidth="fit-content">
-      <a href="/tags/{mobiusTag}">
+      <a href="/tags/{"mobiusTag"}">
         {mobiusContent[mobiusTag.toLowerCase()].icon}
       </a>
-      <a href="/tags/{mobiusTag}">
+      <a href="/tags/{"mobiusTag"}">
         <Typography variant="h7" data-testid={"mobiusTag"}>
         { "options" === mobiusTag ? "DECIDE" : mobiusTag.toUpperCase()}
         </Typography>


### PR DESCRIPTION
Updates reference to mobius by adding a link to the filtered view, and removes the text saying "a practice of"

**What issue does this PR solve?**
#2371 

**Explain the problem and the proposed solution**
The "a practice of" text feels a bit cluttered on the mobile view. Removing it seemed the simplest way of resolving that.
Having the mobius part label is a big improvement, adding the link is a minor enhancement to site navigation.