### PR TITLE
Add node version hint

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -29,7 +29,7 @@ Open Practice Library is built with [Gatsby](https://gatsbyjs.org/) and the [Mat
 ### Quick start
 These steps should work on any platform.
 
-1. [Install Node & npm](https://nodejs.org/en/download/).
+1. [Install Node & npm](https://nodejs.org/en/download/) (should work with Node 20, newer version might cause problems).
 2. Run `npm install -g gatsby-cli` to install Gatsby CLI
 3. Check out this repo.
 4. Navigate to the directory where you checked out this repo.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -29,7 +29,7 @@ Open Practice Library is built with [Gatsby](https://gatsbyjs.org/) and the [Mat
 ### Quick start
 These steps should work on any platform.
 
-1. [Install Node & npm](https://nodejs.org/en/download/) (should work with Node 20, newer version might cause problems).
+1. [Install Node & npm](https://nodejs.org/en/download/) (should work with Node 20 / npm 10, newer version might cause problems).
 2. Run `npm install -g gatsby-cli` to install Gatsby CLI
 3. Check out this repo.
 4. Navigate to the directory where you checked out this repo.


### PR DESCRIPTION
Add a note to advise users which node / npm version to use.

**What issue does this PR solve?**
Well, it does not solve it - but at least it is related to https://github.com/openpracticelibrary/openpracticelibrary/issues/2390

**Explain the problem and the proposed solution**
The problem is, that building the app locally does not seem to work with current node / npm versions. A respective note might save people some trial & error time - and maybe even lower the hurdle to contribute.