### PR TITLE
testing using search tags for additional feature to website

### DIFF
--- a/src/components/shared/Search/SearchContainer.js
+++ b/src/components/shared/Search/SearchContainer.js
@@ -39,6 +39,7 @@ export default function SearchContainer(props) {
   React.useEffect(() => {
     const dataToSearch = new JsSearch.Search(["node", "id"]);
     dataToSearch.addIndex(["node", "frontmatter", "title"]); // sets the index attribute for the data
+    dataToSearch.addIndex(["node", "frontmatter", "searchTag"]); // testing to see if you can add a search term
     dataToSearch.addDocuments(practiceData); // adds the data to be searched
     setState({
       ...state,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -60,6 +60,7 @@ export const pageQuery = graphql`
             mediaGallery {
               link
             }
+            searchTag
           }
         }
       }

--- a/src/pages/practice/10-for-10.md
+++ b/src/pages/practice/10-for-10.md
@@ -7,6 +7,7 @@ authors:
   - julieta-varsano
 tags:
   - ideate
+searchTag: ["community", "number based"]
 mobiusTag: options
 icon: /images/10-for-10-by-aj-smart-1-.jpg
 whatIs: "One of the most common types of workshops that every designer, PM or


### PR DESCRIPTION
**What issue does this PR solve?**

It does not solve any issue directly, but it will contribute to #1800 as a stepping stone for full text searching

**Explain the problem and the proposed solution**

This allows you to tag your practices with certain key words so that when you search, typing in the keywords will also pull up the practice, not just the title. However, this should only be seen as an interim step for #1800 until a full-text search option can be implemented.

An example in the 10-for-10 practice is used for this pull request. Please note one page right now needs to be set with the searchTags option as the field isn't optional (yet)